### PR TITLE
Fix JSONRPC error codes to be the same as in geth

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -722,7 +722,7 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> Result<()
 			let mut message = "VM Exception while processing transaction: revert".to_string();
 			// If error has no selector
 			if data.len() < OFFSET_START {
-				return Err(crate::err(JSON_RPC_ERROR_DEFAULT, message, Some(data)));
+				return Err(crate::err(JSON_RPC_ERROR_REVERT, message, Some(data)));
 			}
 			// A minimum size of error function selector (4) + offset (32) + string length (32)
 			// should contain a utf-8 encoded revert reason.


### PR DESCRIPTION
Changes JSONRPC error code for revertal to be `3` and default error code to be  `-32000` instead of `-32603`. This behavior is the same as in geth which is referring to https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal.