### PR TITLE
fix pallet-evm benchmarking for different node templates

### DIFF
--- a/frame/evm/src/benchmarking.rs
+++ b/frame/evm/src/benchmarking.rs
@@ -71,7 +71,7 @@ benchmarks! {
 
 		let caller = "1000000000000000000000000000000000000001".parse::<H160>().unwrap();
 
-		let mut nonce: u64 = 1;
+		let mut nonce: u64 = 0;
 		let nonce_as_u256: U256 = nonce.into();
 
 		let value = U256::default();
@@ -83,8 +83,8 @@ benchmarks! {
 			contract_bytecode,
 			value,
 			gas_limit_create,
-			Some(U256::from(1_000_000_000)),
-			Some(U256::from(1_000_000_000)),
+			Some(U256::from(1_000_000_000_000_000u128)),
+			Some(U256::from(1_000_000_000_000_000u128)),
 			Some(nonce_as_u256),
 			Vec::new(),
 			is_transactional,
@@ -120,8 +120,8 @@ benchmarks! {
 			encoded_call,
 			value,
 			gas_limit_call,
-			Some(U256::from(1_000_000_000)),
-			Some(U256::from(1_000_000_000)),
+			Some(U256::from(1_000_000_000_000_000u128)),
+			Some(U256::from(1_000_000_000_000_000u128)),
 			Some(nonce_as_u256),
 			Vec::new(),
 			is_transactional,

--- a/frame/evm/src/weights.rs
+++ b/frame/evm/src/weights.rs
@@ -48,12 +48,47 @@ use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_evm.
 pub trait WeightInfo {
+	fn runner_execute(x: u32, ) -> Weight;
 	fn withdraw() -> Weight;
 }
 
 /// Weights for pallet_evm using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	/// Storage: BaseFee BaseFeePerGas (r:1 w:0)
+	/// Proof: BaseFee BaseFeePerGas (max_values: Some(1), max_size: Some(32), added: 527, mode: MaxEncodedLen)
+	/// Storage: System Account (r:2 w:1)
+	/// Proof: System Account (max_values: None, max_size: Some(116), added: 2591, mode: MaxEncodedLen)
+	/// Storage: EVMChainId ChainId (r:1 w:0)
+	/// Proof: EVMChainId ChainId (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+	/// Storage: EVM AccountCodes (r:2 w:0)
+	/// Proof Skipped: EVM AccountCodes (max_values: None, max_size: None, mode: Measured)
+	/// Storage: System Number (r:1 w:0)
+	/// Proof: System Number (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
+	/// Storage: System ExecutionPhase (r:1 w:0)
+	/// Proof: System ExecutionPhase (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: System EventCount (r:1 w:1)
+	/// Proof: System EventCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
+	/// Storage: System Events (r:1 w:1)
+	/// Proof Skipped: System Events (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: System Digest (r:1 w:0)
+	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: EVM AccountStorages (r:1 w:0)
+	/// Proof Skipped: EVM AccountStorages (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Balances TotalIssuance (r:1 w:1)
+	/// Proof: Balances TotalIssuance (max_values: Some(1), max_size: Some(16), added: 511, mode: MaxEncodedLen)
+	/// The range of component `x` is `[1, 10000000]`.
+	fn runner_execute(x: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `913`
+		//  Estimated: `6853`
+		// Minimum execution time: 20_400_192_000 picoseconds.
+		Weight::from_parts(20_767_272_339, 6853)
+			// Standard Error: 33
+			.saturating_add(Weight::from_parts(42, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(13_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
+	}
 	fn withdraw() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
@@ -61,10 +96,45 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 2_000_000 picoseconds.
 		Weight::from_parts(2_000_000, 0)
 	}
+	
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
+	/// Storage: BaseFee BaseFeePerGas (r:1 w:0)
+	/// Proof: BaseFee BaseFeePerGas (max_values: Some(1), max_size: Some(32), added: 527, mode: MaxEncodedLen)
+	/// Storage: System Account (r:2 w:1)
+	/// Proof: System Account (max_values: None, max_size: Some(116), added: 2591, mode: MaxEncodedLen)
+	/// Storage: EVMChainId ChainId (r:1 w:0)
+	/// Proof: EVMChainId ChainId (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+	/// Storage: EVM AccountCodes (r:2 w:0)
+	/// Proof Skipped: EVM AccountCodes (max_values: None, max_size: None, mode: Measured)
+	/// Storage: System Number (r:1 w:0)
+	/// Proof: System Number (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
+	/// Storage: System ExecutionPhase (r:1 w:0)
+	/// Proof: System ExecutionPhase (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: System EventCount (r:1 w:1)
+	/// Proof: System EventCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
+	/// Storage: System Events (r:1 w:1)
+	/// Proof Skipped: System Events (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: System Digest (r:1 w:0)
+	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: EVM AccountStorages (r:1 w:0)
+	/// Proof Skipped: EVM AccountStorages (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Balances TotalIssuance (r:1 w:1)
+	/// Proof: Balances TotalIssuance (max_values: Some(1), max_size: Some(16), added: 511, mode: MaxEncodedLen)
+	/// The range of component `x` is `[1, 10000000]`.
+	fn runner_execute(x: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `913`
+		//  Estimated: `6853`
+		// Minimum execution time: 20_400_192_000 picoseconds.
+		Weight::from_parts(20_767_272_339, 6853)
+			// Standard Error: 33
+			.saturating_add(Weight::from_parts(42, 0).saturating_mul(x.into()))
+			.saturating_add(RocksDbWeight::get().reads(13_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
 	fn withdraw() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`

--- a/frame/evm/src/weights.rs
+++ b/frame/evm/src/weights.rs
@@ -96,7 +96,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 2_000_000 picoseconds.
 		Weight::from_parts(2_000_000, 0)
 	}
-	
 }
 
 // For backwards compatibility and tests

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -33,8 +33,9 @@ function bench {
         --extrinsic="${2}" \
         --execution=wasm \
         --wasm-execution=compiled \
+        --header=HEADER-APACHE2 \
         --output=weights.rs \
-        --template=./benchmarking/frame-weight-template.hbs
+        --template=./.maintain/frame-weight-template.hbs
 }
 
 if  [[ $# -eq 1 && "${1}" == "--help" ]]; then

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -255,10 +255,11 @@ fn testnet_genesis(
 					H160::from_str("1000000000000000000000000000000000000001")
 						.expect("internal H160 is valid; qed"),
 					fp_evm::GenesisAccount {
-						nonce: U256::from(1),
-						balance: U256::from(1_000_000_000_000_000_000_000_000u128),
+						nonce: Default::default(),
+						balance: U256::from_str("0xffffffffffffffffffffffffffffffff")
+							.expect("internal U256 is valid; qed"),
 						storage: Default::default(),
-						code: vec![0x00],
+						code: Default::default(),
 					},
 				);
 				map


### PR DESCRIPTION
This PR fixes the following for the `pallet-evm` benchmark, when it is run with a different node-template than the provided one (e.g. moonbeam):
* Increases the `max_fee_per_gas` for the benchmark for runtimes having a higher fee per gas
* Uses default genesis configuration for the benchmark user (nonce `0`, max balance) - easier to setup for external nodes
* `fn runner_execute` was missing from the generated `WeightInfo` in `weights.rs` - required for the generated weights
* fixes `benchmark.sh` to use the correct handlebars template.