### PR TITLE
Fix benchmarks and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,8 +28,12 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
+      env:
+        RUSTFLAGS: "-Cdebug-assertions=y"
       run: cargo test --release --locked --verbose --all
     - name: Run tests (benchmark tests)
+      env:
+        RUSTFLAGS: "-Cdebug-assertions=y"
       run: cargo test --release --locked --verbose --all --features runtime-benchmarks
 
   integration:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run: cargo test --release --locked --verbose --all
+    - name: Run tests (benchmark tests)
+      run: cargo test --release --locked --verbose --all --features runtime-benchmarks
 
   integration:
     name: 'Run integration tests'

--- a/frame/evm/src/benchmarking.rs
+++ b/frame/evm/src/benchmarking.rs
@@ -69,8 +69,7 @@ benchmarks! {
 			"2eeada8e094193a364736f6c63430008030033"))
 			.expect("Bad hex string");
 
-		let caller = "1000000000000000000000000000000000000001".parse::<H160>().unwrap();
-
+		let caller = H160::default();
 		let mut nonce: u64 = 1;
 		let nonce_as_u256: U256 = nonce.into();
 

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -194,6 +194,8 @@ mod proof_size_test {
 
 	#[test]
 	fn proof_size_subcall_accounting_works() {
+		debug_assert!(false, "CI sound asleep");
+
 		new_test_ext().execute_with(|| {
 			// Create callee contract A
 			let gas_limit: u64 = 1_000_000;


### PR DESCRIPTION
The CI is currently not running the benchmark tests and does therefore not detect failure (as noticed on [SE](https://substrate.stackexchange.com/questions/10344/run-benchmark-fail-test-in-pallet-evm)).  
Further, it is running the tests with `--release` and should therefore not check `debug_assert`s. This MR contains three changes:
- Fix pallet EVM benchmark test (the acc did not have enough balance)
- Also run the benchmark tests in the CI
- Check debug asserts in the CI (not yet done)
