### PR TITLE
Improve the template precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,8 @@ dependencies = [
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
+ "pallet-evm-precompile-blake2",
+ "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,6 +3301,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "precompile-utils",
  "scale-info",
  "sp-api",
  "sp-block-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,8 @@ pallet-dynamic-fee = { version = "4.0.0-dev", path = "frame/dynamic-fee", defaul
 pallet-ethereum = { version = "4.0.0-dev", path = "frame/ethereum", default-features = false }
 pallet-evm = { version = "6.0.0-dev", path = "frame/evm", default-features = false }
 pallet-evm-chain-id = { version = "1.0.0-dev", path = "frame/evm-chain-id", default-features = false }
+pallet-evm-precompile-blake2 = { version = "2.0.0-dev", path = "frame/evm/precompile/blake2", default-features = false }
+pallet-evm-precompile-bn128 = { version = "2.0.0-dev", path = "frame/evm/precompile/bn128", default-features = false }
 pallet-evm-precompile-modexp = { version = "2.0.0-dev", path = "frame/evm/precompile/modexp", default-features = false }
 pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", path = "frame/evm/precompile/sha3fips", default-features = false }
 pallet-evm-precompile-simple = { version = "2.0.0-dev", path = "frame/evm/precompile/simple", default-features = false }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -53,6 +53,8 @@ pallet-dynamic-fee = { workspace = true }
 pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-chain-id = { workspace = true }
+pallet-evm-precompile-blake2 = { workspace = true }
+pallet-evm-precompile-bn128 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
@@ -106,6 +108,8 @@ std = [
 	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-evm-chain-id/std",
+	"pallet-evm-precompile-blake2/std",
+	"pallet-evm-precompile-bn128/std",
 	"pallet-evm-precompile-modexp/std",
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompile-simple/std",

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -47,6 +47,7 @@ fp-account = { workspace = true, features = ["serde"] }
 fp-evm = { workspace = true, features = ["serde"] }
 fp-rpc = { workspace = true }
 fp-self-contained = { workspace = true, features = ["serde"] }
+precompile-utils = { workspace = true }
 # Frontier FRAME
 pallet-base-fee = { workspace = true }
 pallet-dynamic-fee = { workspace = true }
@@ -102,6 +103,7 @@ std = [
 	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",
+	"precompile-utils/std",
 	# Frontier FRAME
 	"pallet-base-fee/std",
 	"pallet-dynamic-fee/std",

--- a/template/runtime/src/precompiles.rs
+++ b/template/runtime/src/precompiles.rs
@@ -1,14 +1,15 @@
-use pallet_evm::{
-	IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
-};
 use sp_core::H160;
 use sp_std::marker::PhantomData;
 
+use pallet_evm::{
+	IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
+};
 use pallet_evm_precompile_blake2::Blake2F;
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
+use precompile_utils::prelude::revert;
 
 pub struct FrontierPrecompiles<R>(PhantomData<R>);
 
@@ -40,6 +41,18 @@ where
 	R: pallet_evm::Config,
 {
 	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
+		let (code_addr, context_addr) = (handle.code_address(), handle.context().address);
+		// For chains that possess their own stateful precompiles, it is advisable to activate this verification measure.
+		// This measure prohibits the use of DELEGATECALL or CALLCODE for any precompiles other than the official Ethereum precompiles, which are inherently stateless.
+		if Self::used_addresses().contains(&code_addr)
+			&& code_addr > hash(9)
+			&& code_addr != context_addr
+		{
+			return Some(Err(revert(
+				"cannot be called with DELEGATECALL or CALLCODE",
+			)));
+		};
+
 		match handle.code_address() {
 			// Ethereum precompiles :
 			a if a == hash(1) => Some(ECRecover::execute(handle)),

--- a/template/runtime/src/precompiles.rs
+++ b/template/runtime/src/precompiles.rs
@@ -4,6 +4,8 @@ use pallet_evm::{
 use sp_core::H160;
 use sp_std::marker::PhantomData;
 
+use pallet_evm_precompile_blake2::Blake2F;
+use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
@@ -17,13 +19,17 @@ where
 	pub fn new() -> Self {
 		Self(Default::default())
 	}
-	pub fn used_addresses() -> [H160; 7] {
+	pub fn used_addresses() -> [H160; 11] {
 		[
 			hash(1),
 			hash(2),
 			hash(3),
 			hash(4),
 			hash(5),
+			hash(6),
+			hash(7),
+			hash(8),
+			hash(9),
 			hash(1024),
 			hash(1025),
 		]
@@ -41,6 +47,10 @@ where
 			a if a == hash(3) => Some(Ripemd160::execute(handle)),
 			a if a == hash(4) => Some(Identity::execute(handle)),
 			a if a == hash(5) => Some(Modexp::execute(handle)),
+			a if a == hash(6) => Some(Bn128Add::execute(handle)),
+			a if a == hash(7) => Some(Bn128Mul::execute(handle)),
+			a if a == hash(8) => Some(Bn128Pairing::execute(handle)),
+			a if a == hash(9) => Some(Blake2F::execute(handle)),
 			// Non-Frontier specific nor Ethereum precompiles :
 			a if a == hash(1024) => Some(Sha3FIPS256::execute(handle)),
 			a if a == hash(1025) => Some(ECRecoverPublicKey::execute(handle)),


### PR DESCRIPTION
This PR improves the template precompile implementation by adding more official Ethereum precompiles and the additional verification for the potential stateful precompiles that are developed by the third parties. There was a potential security issue related to the verification, see https://moonbeam.network/blog/urgent-security-patch-for-custom-precompiles/. So I want to add this to the template runtime to prevent other chains from encountering similar vulnerabilities in the future.