### PR TITLE
Sovereign accounts and EVM system layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,6 +5801,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-system"
+version = "1.0.0-dev"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "mockall",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+]
+
+[[package]]
 name = "pallet-evm-test-vector-support"
 version = "1.0.0-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"frame/ethereum",
 	"frame/evm",
 	"frame/evm-chain-id",
+	"frame/evm-system",
 	"frame/hotfix-sufficients",
 	"frame/evm/precompile/sha3fips",
 	"frame/evm/precompile/simple",
@@ -62,6 +63,7 @@ jsonrpsee = "0.20.3"
 kvdb-rocksdb = "0.19.0"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 log = { version = "0.4.21", default-features = false }
+mockall = "0.11"
 num_enum = { version = "0.7.2", default-features = false }
 parity-db = "0.4.13"
 parking_lot = "0.12.1"

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -158,6 +158,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/frame/evm-system/Cargo.toml
+++ b/frame/evm-system/Cargo.toml
@@ -37,7 +37,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	# Frontier
-  	"fp-evm/std",
+	"fp-evm/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/frame/evm-system/Cargo.toml
+++ b/frame/evm-system/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "pallet-evm-system"
+version = "1.0.0-dev"
+license = "Apache-2.0"
+description = "FRAME EVM SYSTEM pallet."
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+scale-codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true }
+# Substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+# Frontier
+fp-evm = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"scale-codec/std",
+	"scale-info/std",
+	# Substrate
+	"frame-support/std",
+	"frame-system/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	# Frontier
+  	"fp-evm/std",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+]

--- a/frame/evm-system/src/lib.rs
+++ b/frame/evm-system/src/lib.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # EVM System Pallet.
+
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::traits::StoredMap;
+use scale_codec::{Decode, Encode, FullCodec, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::{traits::One, DispatchError, DispatchResult, RuntimeDebug};
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+
+/// Account information.
+#[derive(
+	Clone,
+	Eq,
+	PartialEq,
+	Default,
+	RuntimeDebug,
+	Encode,
+	Decode,
+	TypeInfo,
+	MaxEncodedLen
+)]
+pub struct AccountInfo<Nonce, AccountData> {
+	/// The number of transactions this account has sent.
+	pub nonce: Nonce,
+	/// The additional data that belongs to this account. Used to store the balance(s) in a lot of
+	/// chains.
+	pub data: AccountData,
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use sp_runtime::traits::{AtLeast32Bit, MaybeDisplay};
+	use sp_std::fmt::Debug;
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// The user account identifier type.
+		type AccountId: Parameter
+			+ Member
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ MaybeDisplay
+			+ Ord
+			+ MaxEncodedLen;
+
+		/// This stores the number of previous transactions associated with a sender account.
+		type Nonce: Parameter
+			+ Member
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ Default
+			+ MaybeDisplay
+			+ AtLeast32Bit
+			+ Copy
+			+ MaxEncodedLen;
+
+		/// Data to be associated with an account (other than nonce/transaction counter, which this
+		/// pallet does regardless).
+		type AccountData: Member + FullCodec + Clone + Default + TypeInfo + MaxEncodedLen;
+
+		/// Handler for when a new account has just been created.
+		type OnNewAccount: OnNewAccount<<Self as Config>::AccountId>;
+
+		/// A function that is invoked when an account has been determined to be dead.
+		///
+		/// All resources should be cleaned up associated with the given account.
+		type OnKilledAccount: OnKilledAccount<<Self as Config>::AccountId>;
+	}
+
+	/// The full account information for a particular account ID.
+	#[pallet::storage]
+	pub type Account<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		<T as Config>::AccountId,
+		AccountInfo<<T as Config>::Nonce, <T as Config>::AccountData>,
+		ValueQuery,
+	>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A new account was created.
+		NewAccount { account: <T as Config>::AccountId },
+		/// An account was reaped.
+		KilledAccount { account: <T as Config>::AccountId },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The account already exists in case creating it.
+		AccountAlreadyExist,
+		/// The account doesn't exist in case removing it.
+		AccountNotExist,
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Check the account existence.
+	pub fn account_exists(who: &<T as Config>::AccountId) -> bool {
+		Account::<T>::contains_key(who)
+	}
+
+	/// An account is being created.
+	fn on_created_account(who: <T as Config>::AccountId) {
+		<T as Config>::OnNewAccount::on_new_account(&who);
+		Self::deposit_event(Event::NewAccount { account: who });
+	}
+
+	/// Do anything that needs to be done after an account has been killed.
+	fn on_killed_account(who: <T as Config>::AccountId) {
+		<T as Config>::OnKilledAccount::on_killed_account(&who);
+		Self::deposit_event(Event::KilledAccount { account: who });
+	}
+
+	/// Retrieve the account transaction counter from storage.
+	pub fn account_nonce(who: &<T as Config>::AccountId) -> <T as Config>::Nonce {
+		Account::<T>::get(who).nonce
+	}
+
+	/// Increment a particular account's nonce by 1.
+	pub fn inc_account_nonce(who: &<T as Config>::AccountId) {
+		Account::<T>::mutate(who, |a| a.nonce += <T as pallet::Config>::Nonce::one());
+	}
+
+	/// Create an account.
+	pub fn create_account(who: &<T as Config>::AccountId) -> DispatchResult {
+		if Self::account_exists(who) {
+			return Err(Error::<T>::AccountAlreadyExist.into());
+		}
+
+		Account::<T>::insert(who.clone(), AccountInfo::<_, _>::default());
+		Self::on_created_account(who.clone());
+		Ok(())
+	}
+
+	/// Remove an account.
+	pub fn remove_account(who: &<T as Config>::AccountId) -> DispatchResult {
+		if !Self::account_exists(who) {
+			return Err(Error::<T>::AccountNotExist.into());
+		}
+
+		Account::<T>::remove(who);
+		Self::on_killed_account(who.clone());
+		Ok(())
+	}
+}
+
+impl<T: Config> StoredMap<<T as Config>::AccountId, <T as Config>::AccountData> for Pallet<T> {
+	fn get(k: &<T as Config>::AccountId) -> <T as Config>::AccountData {
+		Account::<T>::get(k).data
+	}
+
+	fn try_mutate_exists<R, E: From<DispatchError>>(
+		k: &<T as Config>::AccountId,
+		f: impl FnOnce(&mut Option<<T as Config>::AccountData>) -> Result<R, E>,
+	) -> Result<R, E> {
+		let (mut maybe_account_data, was_providing) = if Self::account_exists(k) {
+			(Some(Account::<T>::get(k).data), true)
+		} else {
+			(None, false)
+		};
+
+		let result = f(&mut maybe_account_data)?;
+
+		match (maybe_account_data, was_providing) {
+			(Some(data), false) => {
+				Account::<T>::mutate(k, |a| a.data = data);
+				Self::on_created_account(k.clone());
+			}
+			(Some(data), true) => {
+				Account::<T>::mutate(k, |a| a.data = data);
+			}
+			(None, true) => {
+				Account::<T>::remove(k);
+				Self::on_killed_account(k.clone());
+			}
+			(None, false) => {
+				// Do nothing.
+			}
+		}
+
+		Ok(result)
+	}
+}
+
+impl<T: Config> fp_evm::AccountProvider for Pallet<T> {
+	type AccountId = <T as Config>::AccountId;
+	type Nonce = <T as Config>::Nonce;
+
+	fn create_account(who: &Self::AccountId) {
+		let _ = Self::create_account(who);
+	}
+
+	fn remove_account(who: &Self::AccountId) {
+		let _ = Self::remove_account(who);
+	}
+
+	fn account_nonce(who: &Self::AccountId) -> Self::Nonce {
+		Self::account_nonce(who)
+	}
+
+	fn inc_account_nonce(who: &Self::AccountId) {
+		Self::inc_account_nonce(who);
+	}
+}
+
+/// Interface to handle account creation.
+pub trait OnNewAccount<AccountId> {
+	/// A new account `who` has been registered.
+	fn on_new_account(who: &AccountId);
+}
+
+impl<AccountId> OnNewAccount<AccountId> for () {
+	fn on_new_account(_who: &AccountId) {}
+}
+
+/// Interface to handle account killing.
+pub trait OnKilledAccount<AccountId> {
+	/// The account with the given id was reaped.
+	fn on_killed_account(who: &AccountId);
+}
+
+impl<AccountId> OnKilledAccount<AccountId> for () {
+	fn on_killed_account(_who: &AccountId) {}
+}

--- a/frame/evm-system/src/mock.rs
+++ b/frame/evm-system/src/mock.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test mock for unit tests.
+
+use frame_support::traits::{ConstU32, ConstU64};
+use mockall::{mock, predicate::*};
+use sp_core::{H160, H256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use sp_std::{boxed::Box, prelude::*};
+
+use crate::{self as pallet_evm_system, *};
+
+mock! {
+	#[derive(Debug)]
+	pub DummyOnNewAccount {}
+
+	impl OnNewAccount<H160> for DummyOnNewAccount {
+		pub fn on_new_account(who: &H160);
+	}
+}
+
+mock! {
+	#[derive(Debug)]
+	pub DummyOnKilledAccount {}
+
+	impl OnKilledAccount<H160> for DummyOnKilledAccount {
+		pub fn on_killed_account(who: &H160);
+	}
+}
+
+frame_support::construct_runtime! {
+	pub enum Test {
+		System: frame_system,
+		EvmSystem: pallet_evm_system,
+	}
+}
+
+impl frame_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeTask = RuntimeTask;
+	type Nonce = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = H160;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = frame_system::mocking::MockBlock<Self>;
+	type BlockHashCount = ConstU64<250>;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_evm_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type AccountId = H160;
+	type Nonce = u64;
+	type AccountData = u64;
+	type OnNewAccount = MockDummyOnNewAccount;
+	type OnKilledAccount = MockDummyOnKilledAccount;
+}
+
+/// Build test externalities from the custom genesis.
+/// Using this call requires manual assertions on the genesis init logic.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	// Build genesis.
+	let config = RuntimeGenesisConfig {
+		..Default::default()
+	};
+	let storage = config.build_storage().unwrap();
+
+	// Make test externalities from the storage.
+	storage.into()
+}
+
+pub fn runtime_lock() -> std::sync::MutexGuard<'static, ()> {
+	static MOCK_RUNTIME_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+	// Ignore the poisoning for the tests that panic.
+	// We only care about concurrency here, not about the poisoning.
+	match MOCK_RUNTIME_MUTEX.lock() {
+		Ok(guard) => guard,
+		Err(poisoned) => poisoned.into_inner(),
+	}
+}
+
+pub trait TestExternalitiesExt {
+	fn execute_with_ext<R, E>(&mut self, execute: E) -> R
+	where
+		E: for<'e> FnOnce(&'e ()) -> R;
+}
+
+impl TestExternalitiesExt for sp_io::TestExternalities {
+	fn execute_with_ext<R, E>(&mut self, execute: E) -> R
+	where
+		E: for<'e> FnOnce(&'e ()) -> R,
+	{
+		let guard = runtime_lock();
+		let result = self.execute_with(|| execute(&guard));
+		drop(guard);
+		result
+	}
+}

--- a/frame/evm-system/src/tests.rs
+++ b/frame/evm-system/src/tests.rs
@@ -1,0 +1,297 @@
+//! Unit tests.
+
+use sp_std::str::FromStr;
+
+use frame_support::{assert_noop, assert_ok};
+use mockall::predicate;
+use sp_core::H160;
+
+use crate::{mock::*, *};
+
+/// This test verifies that creating account works in the happy path.
+#[test]
+fn create_account_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+
+		// Check test preconditions.
+		assert!(!EvmSystem::account_exists(&account_id));
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Set mock expectations.
+		let on_new_account_ctx = MockDummyOnNewAccount::on_new_account_context();
+		on_new_account_ctx
+			.expect()
+			.once()
+			.with(predicate::eq(account_id))
+			.return_const(());
+
+		// Invoke the function under test.
+		assert_ok!(EvmSystem::create_account(&account_id));
+
+		// Assert state changes.
+		assert!(EvmSystem::account_exists(&account_id));
+		System::assert_has_event(RuntimeEvent::EvmSystem(Event::NewAccount {
+			account: account_id,
+		}));
+
+		// Assert mock invocations.
+		on_new_account_ctx.checkpoint();
+	});
+}
+
+/// This test verifies that creating account fails when the account already exists.
+#[test]
+fn create_account_fails() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+		<Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+
+		// Invoke the function under test.
+		assert_noop!(
+			EvmSystem::create_account(&account_id),
+			Error::<Test>::AccountAlreadyExist
+		);
+	});
+}
+
+/// This test verifies that removing account works in the happy path.
+#[test]
+fn remove_account_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+		<Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Set mock expectations.
+		let on_killed_account_ctx = MockDummyOnKilledAccount::on_killed_account_context();
+		on_killed_account_ctx
+			.expect()
+			.once()
+			.with(predicate::eq(account_id))
+			.return_const(());
+
+		// Invoke the function under test.
+		assert_ok!(EvmSystem::remove_account(&account_id));
+
+		// Assert state changes.
+		assert!(!EvmSystem::account_exists(&account_id));
+		System::assert_has_event(RuntimeEvent::EvmSystem(Event::KilledAccount {
+			account: account_id,
+		}));
+
+		// Assert mock invocations.
+		on_killed_account_ctx.checkpoint();
+	});
+}
+
+/// This test verifies that removing account fails when the account doesn't exist.
+#[test]
+fn remove_account_fails() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+
+		// Invoke the function under test.
+		assert_noop!(
+			EvmSystem::remove_account(&account_id),
+			Error::<Test>::AccountNotExist
+		);
+	});
+}
+
+/// This test verifies that incrementing account nonce works in the happy path.
+#[test]
+fn inc_account_nonce_works() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+
+		// Check test preconditions.
+		let nonce_before = EvmSystem::account_nonce(&account_id);
+
+		// Invoke the function under test.
+		EvmSystem::inc_account_nonce(&account_id);
+
+		// Assert state changes.
+		assert_eq!(EvmSystem::account_nonce(&account_id), nonce_before + 1);
+	});
+}
+
+/// This test verifies that try_mutate_exists works as expected in case data wasn't providing
+/// and returned data is `Some`. As a result, a new account has been created.
+#[test]
+fn try_mutate_exists_account_created() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+
+		// Check test preconditions.
+		assert!(!EvmSystem::account_exists(&account_id));
+
+		// Set mock expectations.
+		let on_new_account_ctx = MockDummyOnNewAccount::on_new_account_context();
+		on_new_account_ctx
+			.expect()
+			.once()
+			.with(predicate::eq(account_id))
+			.return_const(());
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		EvmSystem::try_mutate_exists(&account_id, |maybe_data| -> Result<(), DispatchError> {
+			*maybe_data = Some(1);
+			Ok(())
+		})
+		.unwrap();
+
+		// Assert state changes.
+		assert!(EvmSystem::account_exists(&account_id));
+		assert_eq!(EvmSystem::get(&account_id), 1);
+		System::assert_has_event(RuntimeEvent::EvmSystem(Event::NewAccount {
+			account: account_id,
+		}));
+
+		// Assert mock invocations.
+		on_new_account_ctx.checkpoint();
+	});
+}
+
+/// This test verifies that try_mutate_exists works as expected in case data was providing
+/// and returned data is `Some`. As a result, the account has been updated.
+#[test]
+fn try_mutate_exists_account_updated() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+		let nonce = 1;
+		let data = 1;
+		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+
+		// Check test preconditions.
+		assert!(EvmSystem::account_exists(&account_id));
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		EvmSystem::try_mutate_exists(&account_id, |maybe_data| -> Result<(), DispatchError> {
+			if let Some(ref mut data) = maybe_data {
+				*data += 1;
+			}
+			Ok(())
+		})
+		.unwrap();
+
+		// Assert state changes.
+		assert!(EvmSystem::account_exists(&account_id));
+		assert_eq!(EvmSystem::get(&account_id), data + 1);
+	});
+}
+
+/// This test verifies that try_mutate_exists works as expected in case data was providing
+/// and returned data is `None`. As a result, the account has been removed.
+#[test]
+fn try_mutate_exists_account_removed() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+		let nonce = 1;
+		let data = 1;
+		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+
+		// Check test preconditions.
+		assert!(EvmSystem::account_exists(&account_id));
+
+		// Set mock expectations.
+		let on_killed_account_ctx = MockDummyOnKilledAccount::on_killed_account_context();
+		on_killed_account_ctx
+			.expect()
+			.once()
+			.with(predicate::eq(account_id))
+			.return_const(());
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		EvmSystem::try_mutate_exists(&account_id, |maybe_data| -> Result<(), DispatchError> {
+			*maybe_data = None;
+			Ok(())
+		})
+		.unwrap();
+
+		// Assert state changes.
+		assert!(!EvmSystem::account_exists(&account_id));
+		System::assert_has_event(RuntimeEvent::EvmSystem(Event::KilledAccount {
+			account: account_id,
+		}));
+
+		// Assert mock invocations.
+		on_killed_account_ctx.checkpoint();
+	});
+}
+
+/// This test verifies that try_mutate_exists works as expected in case data wasn't providing
+/// and returned data is `None`. As a result, the account hasn't been created.
+#[test]
+fn try_mutate_exists_account_not_created() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+
+		// Check test preconditions.
+		assert!(!EvmSystem::account_exists(&account_id));
+
+		// Set block number to enable events.
+		System::set_block_number(1);
+
+		// Invoke the function under test.
+		<Account<Test>>::try_mutate_exists(account_id, |maybe_data| -> Result<(), ()> {
+			*maybe_data = None;
+			Ok(())
+		})
+		.unwrap();
+
+		// Assert state changes.
+		assert!(!EvmSystem::account_exists(&account_id));
+	});
+}
+
+/// This test verifies that try_mutate_exists works as expected in case getting error
+/// during data mutation.
+#[test]
+fn try_mutate_exists_fails_without_changes() {
+	new_test_ext().execute_with_ext(|_| {
+		// Prepare test data.
+		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
+		let nonce = 1;
+		let data = 1;
+		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+
+		// Check test preconditions.
+		assert!(EvmSystem::account_exists(&account_id));
+
+		// Invoke the function under test.
+		assert_noop!(
+			<Account<Test>>::try_mutate_exists(account_id, |maybe_data| -> Result<(), ()> {
+				*maybe_data = None;
+				Err(())
+			}),
+			()
+		);
+
+		// Assert state changes.
+		assert!(EvmSystem::account_exists(&account_id));
+		assert_eq!(EvmSystem::get(&account_id), data);
+	});
+}

--- a/frame/evm-system/src/tests.rs
+++ b/frame/evm-system/src/tests.rs
@@ -49,7 +49,7 @@ fn create_account_fails() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test data.
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-		<Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+		<Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
 		// Invoke the function under test.
 		assert_noop!(
@@ -65,7 +65,7 @@ fn remove_account_works() {
 	new_test_ext().execute_with_ext(|_| {
 		// Prepare test data.
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-		<Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+		<Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
 		// Set block number to enable events.
 		System::set_block_number(1);
@@ -175,7 +175,7 @@ fn try_mutate_exists_account_updated() {
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
 		let nonce = 1;
 		let data = 1;
-		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+		<Account<Test>>::insert(account_id, AccountInfo { nonce, data });
 
 		// Check test preconditions.
 		assert!(EvmSystem::account_exists(&account_id));
@@ -207,7 +207,7 @@ fn try_mutate_exists_account_removed() {
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
 		let nonce = 1;
 		let data = 1;
-		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+		<Account<Test>>::insert(account_id, AccountInfo { nonce, data });
 
 		// Check test preconditions.
 		assert!(EvmSystem::account_exists(&account_id));
@@ -276,7 +276,7 @@ fn try_mutate_exists_fails_without_changes() {
 		let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
 		let nonce = 1;
 		let data = 1;
-		<Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+		<Account<Test>>::insert(account_id, AccountInfo { nonce, data });
 
 		// Check test preconditions.
 		assert!(EvmSystem::account_exists(&account_id));

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -54,8 +54,8 @@ impl<T, DispatchValidator, DecodeLimit> Precompile for Dispatch<T, DispatchValid
 where
 	T: pallet_evm::Config,
 	T::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<T::AccountId>>,
-	DispatchValidator: DispatchValidateT<T::AccountId, T::RuntimeCall>,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<pallet_evm::AccountIdOf<T>>>,
+	DispatchValidator: DispatchValidateT<pallet_evm::AccountIdOf<T>, T::RuntimeCall>,
 	DecodeLimit: Get<u32>,
 {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -134,14 +134,15 @@ parameter_types! {
 	pub SuicideQuickClearLimit: u32 = 0;
 }
 impl pallet_evm::Config for Test {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<pallet_evm::AccountIdOf<Self>>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<pallet_evm::AccountIdOf<Self>>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -140,9 +140,9 @@ impl pallet_evm::Config for Test {
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<pallet_evm::AccountIdOf<Self>>;
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<pallet_evm::AccountIdOf<Self>>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -98,9 +98,10 @@ use sp_std::{cmp::min, collections::btree_map::BTreeMap, vec::Vec};
 use fp_account::AccountId20;
 use fp_evm::GenesisAccount;
 pub use fp_evm::{
-	Account, AccountProvider, CallInfo, CreateInfo, ExecutionInfoV2 as ExecutionInfo, FeeCalculator,
-	IsPrecompileResult, LinearCostPrecompile, Log, Precompile, PrecompileFailure, PrecompileHandle,
-	PrecompileOutput, PrecompileResult, PrecompileSet, TransactionValidationError, Vicinity,
+	Account, AccountProvider, CallInfo, CreateInfo, ExecutionInfoV2 as ExecutionInfo,
+	FeeCalculator, IsPrecompileResult, LinearCostPrecompile, Log, Precompile, PrecompileFailure,
+	PrecompileHandle, PrecompileOutput, PrecompileResult, PrecompileSet,
+	TransactionValidationError, Vicinity,
 };
 
 pub use self::{
@@ -583,12 +584,10 @@ pub mod pallet {
 pub type AccountIdOf<T> = <<T as Config>::AccountProvider as AccountProvider>::AccountId;
 
 /// Type alias for currency balance.
-pub type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
 
 /// Type alias for negative imbalance during fees
-type NegativeImbalanceOf<C, T> =
-	<C as Currency<AccountIdOf<T>>>::NegativeImbalance;
+type NegativeImbalanceOf<C, T> = <C as Currency<AccountIdOf<T>>>::NegativeImbalance;
 
 #[derive(
 	Debug,
@@ -955,14 +954,10 @@ impl<T, C, OU> OnChargeEVMTransaction<T> for EVMCurrencyAdapter<C, OU>
 where
 	T: Config,
 	C: Currency<AccountIdOf<T>>,
-	C::PositiveImbalance: Imbalance<
-		<C as Currency<AccountIdOf<T>>>::Balance,
-		Opposite = C::NegativeImbalance,
-	>,
-	C::NegativeImbalance: Imbalance<
-		<C as Currency<AccountIdOf<T>>>::Balance,
-		Opposite = C::PositiveImbalance,
-	>,
+	C::PositiveImbalance:
+		Imbalance<<C as Currency<AccountIdOf<T>>>::Balance, Opposite = C::NegativeImbalance>,
+	C::NegativeImbalance:
+		Imbalance<<C as Currency<AccountIdOf<T>>>::Balance, Opposite = C::PositiveImbalance>,
 	OU: OnUnbalanced<NegativeImbalanceOf<C, T>>,
 	U256: UniqueSaturatedInto<<C as Currency<AccountIdOf<T>>>::Balance>,
 {
@@ -1046,22 +1041,22 @@ where
 
 /// Implementation for () does not specify what to do with imbalance
 impl<T> OnChargeEVMTransaction<T> for ()
-	where
+where
 	T: Config,
-	<T::Currency as Currency<AccountIdOf<T>>>::PositiveImbalance:
-		Imbalance<<T::Currency as Currency<AccountIdOf<T>>>::Balance, Opposite = <T::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance>,
-	<T::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance:
-Imbalance<<T::Currency as Currency<AccountIdOf<T>>>::Balance, Opposite = <T::Currency as Currency<AccountIdOf<T>>>::PositiveImbalance>,
-U256: UniqueSaturatedInto<BalanceOf<T>>,
-
+	<T::Currency as Currency<AccountIdOf<T>>>::PositiveImbalance: Imbalance<
+		<T::Currency as Currency<AccountIdOf<T>>>::Balance,
+		Opposite = <T::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance,
+	>,
+	<T::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance: Imbalance<
+		<T::Currency as Currency<AccountIdOf<T>>>::Balance,
+		Opposite = <T::Currency as Currency<AccountIdOf<T>>>::PositiveImbalance,
+	>,
+	U256: UniqueSaturatedInto<BalanceOf<T>>,
 {
 	// Kept type as Option to satisfy bound of Default
 	type LiquidityInfo = Option<NegativeImbalanceOf<T::Currency, T>>;
 
-	fn withdraw_fee(
-		who: &H160,
-		fee: U256,
-	) -> Result<Self::LiquidityInfo, Error<T>> {
+	fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>> {
 		EVMCurrencyAdapter::<<T as Config>::Currency, ()>::withdraw_fee(who, fee)
 	}
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -1099,17 +1099,17 @@ impl<T: frame_system::Config> AccountProvider for NativeSystemAccountProvider<T>
 	type Nonce = T::Nonce;
 
 	fn account_nonce(who: &Self::AccountId) -> Self::Nonce {
-		frame_system::Pallet::<T>::account_nonce(&who)
+		frame_system::Pallet::<T>::account_nonce(who)
 	}
 
 	fn inc_account_nonce(who: &Self::AccountId) {
-		frame_system::Pallet::<T>::inc_account_nonce(&who)
+		frame_system::Pallet::<T>::inc_account_nonce(who)
 	}
 
 	fn create_account(who: &Self::AccountId) {
-		let _ = frame_system::Pallet::<T>::inc_sufficients(&who);
+		let _ = frame_system::Pallet::<T>::inc_sufficients(who);
 	}
 	fn remove_account(who: &Self::AccountId) {
-		let _ = frame_system::Pallet::<T>::dec_sufficients(&who);
+		let _ = frame_system::Pallet::<T>::dec_sufficients(who);
 	}
 }

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -132,14 +132,15 @@ parameter_types! {
 	pub SuicideQuickClearLimit: u32 = 0;
 }
 impl crate::Config for Test {
+	type AccountProvider = crate::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = FixedGasPrice;
 	type GasWeightMapping = crate::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = crate::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<crate::AccountIdOf<Self>>;
 
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<crate::AccountIdOf<Self>>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -138,9 +138,9 @@ impl crate::Config for Test {
 	type WeightPerGas = WeightPerGas;
 
 	type BlockHashMapping = crate::SubstrateBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressRoot<crate::AccountIdOf<Self>>;
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
 
-	type WithdrawOrigin = EnsureAddressNever<crate::AccountIdOf<Self>>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
 	type AddressMapping = IdentityAddressMapping;
 	type Currency = Balances;
 

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -48,9 +48,9 @@ use fp_evm::{
 };
 
 use crate::{
-	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountProvider, AccountStorages,
-	AddressMapping, BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
-	OnCreate, Pallet, RunnerError,
+	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountProvider,
+	AccountStorages, AddressMapping, BalanceOf, BlockHashMapping, Config, Error, Event,
+	FeeCalculator, OnChargeEVMTransaction, OnCreate, Pallet, RunnerError,
 };
 
 #[cfg(feature = "forbid-evm-reentrancy")]

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -48,8 +48,8 @@ use fp_evm::{
 };
 
 use crate::{
-	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountStorages, AddressMapping,
-	BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
+	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountProvider, AccountStorages,
+	AddressMapping, BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
 	OnCreate, Pallet, RunnerError,
 };
 
@@ -841,7 +841,7 @@ where
 
 	fn inc_nonce(&mut self, address: H160) -> Result<(), ExitError> {
 		let account_id = T::AddressMapping::into_account_id(address);
-		frame_system::Pallet::<T>::inc_account_nonce(&account_id);
+		T::AccountProvider::inc_account_nonce(&account_id);
 		Ok(())
 	}
 

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -1088,7 +1088,7 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 	}
 
 	/// Return the list of addresses contained in this PrecompileSet.
-	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
+	pub fn used_addresses() -> impl Iterator<Item = pallet_evm::AccountIdOf<R>> {
 		Self::new()
 			.inner
 			.used_addresses()

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -225,6 +225,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/primitives/evm/src/account_provider.rs
+++ b/primitives/evm/src/account_provider.rs
@@ -16,11 +16,11 @@ pub trait AccountProvider {
 	///
 	/// Represent the account itself in accounts records.
 	type AccountId;
-	/// Account index (aka nonce) type.
+	/// Account nonce type.
 	///
 	/// The number that helps to ensure that each transaction in the network is unique
 	/// for particular account.
-	type Index: AtLeast32Bit;
+	type Nonce: AtLeast32Bit;
 
 	/// Creates a new account in accounts records.
 	///
@@ -33,7 +33,7 @@ pub trait AccountProvider {
 	/// Return current account nonce value.
 	///
 	/// Used to represent account basic information in EVM format.
-	fn account_nonce(who: &Self::AccountId) -> Self::Index;
+	fn account_nonce(who: &Self::AccountId) -> Self::Nonce;
 	/// Increment a particular account's nonce value.
 	///
 	/// Incremented with each new transaction submitted by the account.

--- a/primitives/evm/src/account_provider.rs
+++ b/primitives/evm/src/account_provider.rs
@@ -1,0 +1,41 @@
+//! Custom account provider logic.
+
+use sp_runtime::traits::AtLeast32Bit;
+
+/// The account provider interface abstraction layer.
+///
+/// Expose account related logic that `pallet_evm` required to control accounts existence
+/// in the network and their transactions uniqueness. By default, the pallet operates native
+/// system accounts records that `frame_system` provides.
+///
+/// The interface allow any custom account provider logic to be used instead of
+/// just using `frame_system` account provider. The accounts records should store nonce value
+/// for each account at least.
+pub trait AccountProvider {
+	/// The account identifier type.
+	///
+	/// Represent the account itself in accounts records.
+	type AccountId;
+	/// Account index (aka nonce) type.
+	///
+	/// The number that helps to ensure that each transaction in the network is unique
+	/// for particular account.
+	type Index: AtLeast32Bit;
+
+	/// Creates a new account in accounts records.
+	///
+	/// The account associated with new created address EVM.
+	fn create_account(who: &Self::AccountId);
+	/// Removes an account from accounts records.
+	///
+	/// The account associated with removed address from EVM.
+	fn remove_account(who: &Self::AccountId);
+	/// Return current account nonce value.
+	///
+	/// Used to represent account basic information in EVM format.
+	fn account_nonce(who: &Self::AccountId) -> Self::Index;
+	/// Increment a particular account's nonce value.
+	///
+	/// Incremented with each new transaction submitted by the account.
+	fn inc_account_nonce(who: &Self::AccountId);
+}

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -18,9 +18,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
 
+mod account_provider;
 mod precompile;
 mod validation;
-mod account_provider;
 
 use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight};
 use scale_codec::{Decode, Encode};

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod precompile;
 mod validation;
+mod account_provider;
 
 use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight};
 use scale_codec::{Decode, Encode};
@@ -36,6 +37,7 @@ pub use evm::{
 };
 
 pub use self::{
+	account_provider::AccountProvider,
 	precompile::{
 		Context, ExitError, ExitRevert, ExitSucceed, IsPrecompileResult, LinearCostPrecompile,
 		Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileResult,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -330,6 +330,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = pallet_evm::NativeSystemAccountProvider<Self>;
 	type FeeCalculator = BaseFee;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;


### PR DESCRIPTION
The main goal of this pallet is to provide the opportunity to have a completely separate independent account system from native substrate system accounts. In the case when the native account system needs to work with 32 byte addresses, but EVM-compatibility with 20 byte addresses is required as well for some reason, there is a need to map these addresses, which can cause a lot of inconvenience to users and developers, since the 32 and 20 addresses are cryptographically cannot be matched 1 to 1 bijectively.

This pallet will make it possible, within one runtime, to define two independent separate account systems (native and evm), the main advantages of which are:
- no need to synthetically map 20-byte addresses with 32-byte ones
- EVM accounts can exist independently with their own logic, for example, there is no need for proper management of consumers and providers, which are needed just for the native account system.