### PR TITLE
Fix: Remove `super` visibility of `Pending` storage in `pallet-ethereum`

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -319,7 +319,7 @@ pub mod pallet {
 
 	/// Current building block's transactions and receipts.
 	#[pallet::storage]
-	pub(super) type Pending<T: Config> =
+	pub type Pending<T: Config> =
 		StorageValue<_, Vec<(Transaction, TransactionStatus, Receipt)>, ValueQuery>;
 
 	/// The current Ethereum block.


### PR DESCRIPTION
Hi

I guess it was a typo after [removing deprecated getters](https://github.com/polkadot-evm/frontier/pull/1034/files#diff-4a4404da981c8fc7fd4a5f9245136407d480ae2568de69e207c12066cb9473f5). All other storages of `pallet-ethereum` remove their `super` visibility except `Pending` storage. Blocking any interaction with it from the outside.

This PR removes the `super` visibility to be able to access them from other pallets.