### PR TITLE
Fix: Remove super visibility of Pending storage in pallet-ethereum

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -319,7 +319,7 @@ pub mod pallet {
 
 	/// Current building block's transactions and receipts.
 	#[pallet::storage]
-	pub(super) type Pending<T: Config> =
+	pub type Pending<T: Config> =
 		StorageValue<_, Vec<(Transaction, TransactionStatus, Receipt)>, ValueQuery>;
 
 	/// The current Ethereum block.


### PR DESCRIPTION
Replicate https://github.com/polkadot-evm/frontier/pull/1346 for `polkadot-v1.1.0`