### PR TITLE
used_addresses_h160 getter for the PrecompileSetBuilder

### DIFF
--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -1089,14 +1089,13 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 
 	/// Return the list of mapped addresses contained in this PrecompileSet.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
-		Self::used_addresses_h160()
-			.map(R::AddressMapping::into_account_id)
+		Self::used_addresses_h160().map(R::AddressMapping::into_account_id)
 	}
 
 	/// Return the list of H160 addresses contained in this PrecompileSet.
 	pub fn used_addresses_h160() -> impl Iterator<Item = H160> {
-        Self::new().inner.used_addresses().into_iter()
-    }
+		Self::new().inner.used_addresses().into_iter()
+	}
 
 	pub fn summarize_checks(&self) -> Vec<PrecompileCheckSummary> {
 		self.inner.summarize_checks()

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -1087,14 +1087,16 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 		}
 	}
 
-	/// Return the list of addresses contained in this PrecompileSet.
+	/// Return the list of mapped addresses contained in this PrecompileSet.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
-		Self::new()
-			.inner
-			.used_addresses()
-			.into_iter()
+		Self::used_addresses_h160()
 			.map(R::AddressMapping::into_account_id)
 	}
+
+	/// Return the list of H160 addresses contained in this PrecompileSet.
+	pub fn used_addresses_h160() -> impl Iterator<Item = H160> {
+        Self::new().inner.used_addresses().into_iter()
+    }
 
 	pub fn summarize_checks(&self) -> Vec<PrecompileCheckSummary> {
 		self.inner.summarize_checks()


### PR DESCRIPTION
Adds an additional getter for `used_addresses` in the `PrecompileSetBuilder`.
Unlike the existing one which returns mapped addressed, the new one returns `H160` addresses.

Perhaps it would be best to remove the old one, but I've kept it for backwards compatibility.