### PR TITLE
ignore md files for workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - master
       - 'polkadot-v**'
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - master
       - 'polkadot-v**'
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Don't run github actions when only `.md` files are changed. 

This will: 
- save resources (for the quota of the repo), 
- pull-requests can be merged faster,
- less electric consumption 🌱