### PR TITLE
support eth_call for past blocks with old runtimes

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -101,7 +101,11 @@ where
 			(
 				details.gas_price,
 				// Old runtimes require max_fee_per_gas to be None for non transactional calls.
-				if details.max_fee_per_gas == Some(U256::zero()) { None } else { details.max_fee_per_gas },
+				if details.max_fee_per_gas == Some(U256::zero()) {
+					None
+				} else {
+					details.max_fee_per_gas
+				},
 				details.max_priority_fee_per_gas,
 			)
 		};

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -100,7 +100,8 @@ where
 			let details = fee_details(gas_price, max_fee_per_gas, max_priority_fee_per_gas)?;
 			(
 				details.gas_price,
-				details.max_fee_per_gas,
+				// Old runtimes require max_fee_per_gas to be None for non transactional calls.
+				if details.max_fee_per_gas == Some(U256::zero()) { None } else { details.max_fee_per_gas },
 				details.max_priority_fee_per_gas,
 			)
 		};


### PR DESCRIPTION
This PR https://github.com/polkadot-evm/frontier/pull/1257 introduced a regression that make the client not compatible with old runtimes.

Old runtimes doesn't check properly non transactional evm calls, old runtimes rely on the fact that max_fee_per_gas is None to consider the evm call non transactional.

It introduced a bug in Moonbeam where eth_call against past blocks produce the `BalanceLow` error.

Because we can't change old runtimes, the client should not set `max_fee_per_gas` as `Some(zero)`, otherwize old runtimes will assume that the evm call is transactional.
