### PR TITLE
Revert "support eth_call for past blocks with old runtimes"

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -100,12 +100,7 @@ where
 			let details = fee_details(gas_price, max_fee_per_gas, max_priority_fee_per_gas)?;
 			(
 				details.gas_price,
-				// Old runtimes require max_fee_per_gas to be None for non transactional calls.
-				if details.max_fee_per_gas == Some(U256::zero()) {
-					None
-				} else {
-					details.max_fee_per_gas
-				},
+				details.max_fee_per_gas,
 				details.max_priority_fee_per_gas,
 			)
 		};


### PR DESCRIPTION
Reverts polkadot-evm/frontier#1404

The reason: https://github.com/polkadot-evm/frontier/pull/1409#issuecomment-2084767553

@sorpaas @librelois @ahmadkaouk 