### PR TITLE
chore: remove sp-std usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -2764,7 +2763,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -2785,7 +2783,6 @@ dependencies = [
  "fp-evm",
  "frame-support",
  "parity-scale-codec",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -2800,7 +2797,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -2816,7 +2812,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -3194,7 +3189,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -5620,7 +5614,6 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -5649,7 +5642,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -5677,7 +5669,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -5768,7 +5759,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -5825,7 +5815,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -5876,7 +5865,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]
@@ -6498,7 +6486,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
  "sp-weights",
  "staging-xcm",
 ]
@@ -6517,7 +6504,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
  "syn 1.0.109",
  "trybuild",
 ]
@@ -6540,7 +6526,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.10.1)",
 ]
 
 [[package]]

--- a/frame/dynamic-fee/Cargo.toml
+++ b/frame/dynamic-fee/Cargo.toml
@@ -18,7 +18,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-dynamic-fee = { workspace = true }
 fp-evm = { workspace = true }
@@ -37,7 +36,6 @@ std = [
 	# Substrate
 	"sp-core/std",
 	"sp-inherents/std",
-	"sp-std/std",
 	# Substrate
 	"frame-system/std",
 	"frame-support/std",

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -22,10 +22,10 @@
 #[cfg(test)]
 mod tests;
 
+use core::cmp::{max, min};
 use frame_support::{inherent::IsFatalError, traits::Get, weights::Weight};
 use sp_core::U256;
 use sp_inherents::{InherentData, InherentIdentifier};
-use sp_std::cmp::{max, min};
 
 pub use self::pallet::*;
 #[cfg(feature = "std")]

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -21,7 +21,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-consensus = { workspace = true }
 fp-ethereum = { workspace = true }
@@ -55,7 +54,6 @@ std = [
 	"frame-system/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	# Frontier
 	"fp-consensus/std",
 	"fp-ethereum/std",

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -25,11 +25,15 @@
 #![allow(clippy::comparison_chain, clippy::large_enum_variant)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
 #[cfg(all(feature = "std", test))]
 mod mock;
 #[cfg(all(feature = "std", test))]
 mod tests;
 
+use alloc::{vec, vec::Vec};
+use core::marker::PhantomData;
 pub use ethereum::{
 	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
 	TransactionAction, TransactionV2 as Transaction,
@@ -55,7 +59,6 @@ use sp_runtime::{
 	},
 	RuntimeDebug, SaturatedConversion,
 };
-use sp_std::{marker::PhantomData, prelude::*};
 // Frontier
 use fp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 pub use fp_ethereum::TransactionData;
@@ -689,7 +692,7 @@ impl<T: Config> Pallet<T> {
 			PostDispatchInfo {
 				actual_weight: {
 					let mut gas_to_weight = T::GasWeightMapping::gas_to_weight(
-						sp_std::cmp::max(
+						core::cmp::max(
 							used_gas.standard.unique_saturated_into(),
 							used_gas.effective.unique_saturated_into(),
 						),

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -29,7 +29,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-account = { workspace = true }
 fp-evm = { workspace = true, features = ["serde"] }
@@ -59,7 +58,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	# Frontier
 	"fp-account/std",
 	"fp-evm/std",

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -26,7 +26,6 @@ pallet-utility = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 sp-runtime = { workspace = true, features = ["default"] }
-sp-std = { workspace = true, features = ["default"] }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -17,6 +17,8 @@
 
 //! Test mock for unit tests and benchmarking
 
+use alloc::boxed::Box;
+use core::str::FromStr;
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{ConstU32, FindAuthor},
@@ -25,7 +27,6 @@ use frame_support::{
 };
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
-use sp_std::{boxed::Box, prelude::*, str::FromStr};
 
 use fp_evm::{ExitError, ExitReason, Transfer};
 use pallet_evm::{

--- a/frame/evm/precompile/storage-cleaner/Cargo.toml
+++ b/frame/evm/precompile/storage-cleaner/Cargo.toml
@@ -14,7 +14,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
@@ -31,7 +30,6 @@ rlp = { workspace = true }
 sp-core = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 sp-runtime = { workspace = true, features = ["default"] }
-sp-std = { workspace = true, features = ["default"] }
 
 # Frontier
 precompile-utils = { workspace = true, features = ["std", "testing"] }
@@ -45,7 +43,6 @@ std = [
 	"frame-system/std",
 	"sp-runtime/std",
 	"sp-core/std",
-	"sp-std/std",
 	# Frontier
 	"fp-evm/std",
 	"pallet-evm/std",

--- a/frame/evm/precompile/storage-cleaner/src/lib.rs
+++ b/frame/evm/precompile/storage-cleaner/src/lib.rs
@@ -21,13 +21,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use fp_evm::{PrecompileFailure, ACCOUNT_BASIC_PROOF_SIZE, ACCOUNT_STORAGE_PROOF_SIZE};
 use pallet_evm::AddressMapping;
 use precompile_utils::{prelude::*, EvmResult};
 use sp_core::H160;
 use sp_runtime::traits::ConstU32;
-use sp_std::vec::Vec;
 
 #[cfg(test)]
 mod mock;

--- a/frame/evm/src/benchmarking.rs
+++ b/frame/evm/src/benchmarking.rs
@@ -35,7 +35,7 @@ benchmarks! {
 
 		use rlp::RlpStream;
 		use sp_core::{H160, U256};
-		use sp_std::vec;
+		use alloc::vec;
 
 		// contract bytecode below is for:
 		//

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -55,6 +55,8 @@
 #![warn(unused_crate_dependencies)]
 #![allow(clippy::too_many_arguments)]
 
+extern crate alloc;
+
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
@@ -65,6 +67,8 @@ pub mod runner;
 mod tests;
 pub mod weights;
 
+use alloc::{collections::btree_map::BTreeMap, vec::Vec};
+use core::cmp::min;
 pub use evm::{
 	Config as EvmConfig, Context, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed,
 };
@@ -94,7 +98,6 @@ use sp_runtime::{
 	traits::{BadOrigin, NumberFor, Saturating, UniqueSaturatedInto, Zero},
 	AccountId32, DispatchErrorWithPostInfo,
 };
-use sp_std::{cmp::min, collections::btree_map::BTreeMap, vec::Vec};
 // Frontier
 use fp_account::AccountId20;
 use fp_evm::GenesisAccount;
@@ -651,7 +654,7 @@ where
 }
 
 /// Ensure that the origin is root.
-pub struct EnsureAddressRoot<AccountId>(sp_std::marker::PhantomData<AccountId>);
+pub struct EnsureAddressRoot<AccountId>(core::marker::PhantomData<AccountId>);
 
 impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressRoot<AccountId>
 where
@@ -668,7 +671,7 @@ where
 }
 
 /// Ensure that the origin never happens.
-pub struct EnsureAddressNever<AccountId>(sp_std::marker::PhantomData<AccountId>);
+pub struct EnsureAddressNever<AccountId>(core::marker::PhantomData<AccountId>);
 
 impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressNever<AccountId> {
 	type Success = AccountId;
@@ -731,7 +734,7 @@ impl<T: From<H160>> AddressMapping<T> for IdentityAddressMapping {
 }
 
 /// Hashed address mapping.
-pub struct HashedAddressMapping<H>(sp_std::marker::PhantomData<H>);
+pub struct HashedAddressMapping<H>(core::marker::PhantomData<H>);
 
 impl<H: Hasher<Out = H256>> AddressMapping<AccountId32> for HashedAddressMapping<H> {
 	fn into_account_id(address: H160) -> AccountId32 {
@@ -750,7 +753,7 @@ pub trait BlockHashMapping {
 }
 
 /// Returns the Substrate block hash by number.
-pub struct SubstrateBlockHashMapping<T>(sp_std::marker::PhantomData<T>);
+pub struct SubstrateBlockHashMapping<T>(core::marker::PhantomData<T>);
 impl<T: Config> BlockHashMapping for SubstrateBlockHashMapping<T> {
 	fn block_hash(number: u32) -> H256 {
 		let number = <NumberFor<T::Block>>::from(number);
@@ -764,7 +767,7 @@ pub trait GasWeightMapping {
 	fn weight_to_gas(weight: Weight) -> u64;
 }
 
-pub struct FixedGasWeightMapping<T>(sp_std::marker::PhantomData<T>);
+pub struct FixedGasWeightMapping<T>(core::marker::PhantomData<T>);
 impl<T: Config> GasWeightMapping for FixedGasWeightMapping<T> {
 	fn gas_to_weight(gas: u64, without_base_weight: bool) -> Weight {
 		let mut weight = T::WeightPerGas::get().saturating_mul(gas);
@@ -953,7 +956,7 @@ pub trait OnChargeEVMTransaction<T: Config> {
 /// trait (eg. the pallet_balances) using an unbalance handler (implementing
 /// `OnUnbalanced`).
 /// Similar to `CurrencyAdapter` of `pallet_transaction_payment`
-pub struct EVMCurrencyAdapter<C, OU>(sp_std::marker::PhantomData<(C, OU)>);
+pub struct EVMCurrencyAdapter<C, OU>(core::marker::PhantomData<(C, OU)>);
 
 impl<T, C, OU> OnChargeEVMTransaction<T> for EVMCurrencyAdapter<C, OU>
 where
@@ -1053,7 +1056,7 @@ where
 ///
 /// Equivalent of `EVMCurrencyAdapter` but for fungible traits. Similar to `FungibleAdapter` of
 /// `pallet_transaction_payment`
-pub struct EVMFungibleAdapter<F, OU>(sp_std::marker::PhantomData<(F, OU)>);
+pub struct EVMFungibleAdapter<F, OU>(core::marker::PhantomData<(F, OU)>);
 
 impl<T, F, OU> OnChargeEVMTransaction<T> for EVMFungibleAdapter<F, OU>
 where

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -17,6 +17,8 @@
 
 //! Test mock for unit tests and benchmarking
 
+use alloc::boxed::Box;
+use core::str::FromStr;
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{ConstU32, FindAuthor},
@@ -27,7 +29,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	ConsensusEngineId,
 };
-use sp_std::{boxed::Box, prelude::*, str::FromStr};
 
 use crate::{
 	EnsureAddressNever, EnsureAddressRoot, FeeCalculator, IdentityAddressMapping,

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -18,9 +18,9 @@
 pub mod stack;
 
 use crate::{Config, Weight};
+use alloc::vec::Vec;
 use fp_evm::{CallInfo, CreateInfo};
 use sp_core::{H160, H256, U256};
-use sp_std::vec::Vec;
 
 #[derive(Debug)]
 pub struct RunnerError<E: Into<sp_runtime::DispatchError>> {

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -17,6 +17,12 @@
 
 //! EVM stack-based runner.
 
+use alloc::{
+	boxed::Box,
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	vec::Vec,
+};
+use core::{marker::PhantomData, mem};
 use evm::{
 	backend::Backend as BackendT,
 	executor::stack::{Accessed, StackExecutor, StackState as StackStateT, StackSubstateMetadata},
@@ -33,13 +39,6 @@ use frame_support::{
 };
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::UniqueSaturatedInto;
-use sp_std::{
-	boxed::Box,
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-	marker::PhantomData,
-	mem,
-	vec::Vec,
-};
 // Frontier
 use fp_evm::{
 	AccessedStorage, CallInfo, CreateInfo, ExecutionInfoV2, IsPrecompileResult, Log, PrecompileSet,
@@ -249,7 +248,7 @@ where
 		// Post execution.
 		let used_gas = executor.used_gas();
 		let effective_gas = match executor.state().weight_info() {
-			Some(weight_info) => U256::from(sp_std::cmp::max(
+			Some(weight_info) => U256::from(core::cmp::max(
 				used_gas,
 				weight_info
 					.proof_size_usage
@@ -848,7 +847,7 @@ where
 	fn set_storage(&mut self, address: H160, index: H256, value: H256) {
 		// We cache the current value if this is the first time we modify it
 		// in the transaction.
-		use sp_std::collections::btree_map::Entry::Vacant;
+		use alloc::collections::btree_map::Entry::Vacant;
 		if let Vacant(e) = self.original_storage.entry((address, index)) {
 			let original = <AccountStorages<T>>::get(address, index);
 			// No need to cache if same value.

--- a/frame/hotfix-sufficients/Cargo.toml
+++ b/frame/hotfix-sufficients/Cargo.toml
@@ -20,7 +20,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 pallet-evm = { workspace = true }
 
@@ -39,7 +38,6 @@ std = [
 	"frame-system/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	# Frontier
 	"pallet-evm/std",
 ]

--- a/frame/hotfix-sufficients/src/lib.rs
+++ b/frame/hotfix-sufficients/src/lib.rs
@@ -18,6 +18,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 #[cfg(test)]
@@ -26,11 +28,11 @@ mod mock;
 mod tests;
 pub mod weights;
 
+use alloc::vec::Vec;
 // Substrate
 use frame_support::dispatch::PostDispatchInfo;
 use sp_core::H160;
 use sp_runtime::traits::Zero;
-use sp_std::vec::Vec;
 // Frontier
 pub use pallet_evm::AddressMapping;
 

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -27,7 +27,6 @@ scale-codec = { package = "parity-scale-codec", workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-weights = { workspace = true }
 
 # Frontier
@@ -53,7 +52,6 @@ std = [
 	"scale-codec/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-std/std",
 	"xcm?/std",
 ]
 codec-xcm = ["xcm"]

--- a/precompiles/macro/Cargo.toml
+++ b/precompiles/macro/Cargo.toml
@@ -30,4 +30,3 @@ precompile-utils = { path = "../", features = ["testing"] }
 fp-evm = { workspace = true }
 frame-support = { workspace = true }
 sp-crypto-hashing = { workspace = true }
-sp-std = { workspace = true }

--- a/precompiles/macro/docs/precompile_macro.md
+++ b/precompiles/macro/docs/precompile_macro.md
@@ -1,4 +1,4 @@
-# `#[precompile]` procedural macro.
+# `#[precompile]` procedural macro
 
 This procedural macro allows to simplify the implementation of an EVM precompile or precompile set
 using an `impl` block with annotations to automatically generate:

--- a/precompiles/macro/src/precompile/expand.rs
+++ b/precompiles/macro/src/precompile/expand.rs
@@ -219,7 +219,7 @@ impl Precompile {
 					}
 				)*
 
-				pub fn encode(self) -> ::sp_std::vec::Vec<u8> {
+				pub fn encode(self) -> ::alloc::vec::Vec<u8> {
 					use ::precompile_utils::solidity::codec::Writer;
 					match self {
 						#(
@@ -232,10 +232,10 @@ impl Precompile {
 				}
 			}
 
-			impl #impl_generics From<#enum_ident #ty_generics> for ::sp_std::vec::Vec<u8>
+			impl #impl_generics From<#enum_ident #ty_generics> for ::alloc::vec::Vec<u8>
 			#where_clause
 			{
-				fn from(a: #enum_ident #ty_generics) -> ::sp_std::vec::Vec<u8> {
+				fn from(a: #enum_ident #ty_generics) -> ::alloc::vec::Vec<u8> {
 					a.encode()
 				}
 			}

--- a/precompiles/macro/src/precompile/expand.rs
+++ b/precompiles/macro/src/precompile/expand.rs
@@ -219,7 +219,7 @@ impl Precompile {
 					}
 				)*
 
-				pub fn encode(self) -> ::alloc::vec::Vec<u8> {
+				pub fn encode(self) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 					use ::precompile_utils::solidity::codec::Writer;
 					match self {
 						#(
@@ -232,10 +232,10 @@ impl Precompile {
 				}
 			}
 
-			impl #impl_generics From<#enum_ident #ty_generics> for ::alloc::vec::Vec<u8>
+			impl #impl_generics From<#enum_ident #ty_generics> for ::precompile_utils::__alloc::vec::Vec<u8>
 			#where_clause
 			{
-				fn from(a: #enum_ident #ty_generics) -> ::alloc::vec::Vec<u8> {
+				fn from(a: #enum_ident #ty_generics) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 					a.encode()
 				}
 			}

--- a/precompiles/macro/tests/expand/precompile.expanded.rs
+++ b/precompiles/macro/tests/expand/precompile.expanded.rs
@@ -240,7 +240,7 @@ where
 	pub fn fallback_selectors() -> &'static [u32] {
 		&[]
 	}
-	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
+	pub fn encode(self) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::batch_all {
@@ -283,11 +283,11 @@ where
 		}
 	}
 }
-impl<Runtime> From<BatchPrecompileCall<Runtime>> for ::alloc::vec::Vec<u8>
+impl<Runtime> From<BatchPrecompileCall<Runtime>> for ::precompile_utils::__alloc::vec::Vec<u8>
 where
 	Runtime: Get<u32>,
 {
-	fn from(a: BatchPrecompileCall<Runtime>) -> ::alloc::vec::Vec<u8> {
+	fn from(a: BatchPrecompileCall<Runtime>) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/macro/tests/expand/precompile.expanded.rs
+++ b/precompiles/macro/tests/expand/precompile.expanded.rs
@@ -240,7 +240,7 @@ where
 	pub fn fallback_selectors() -> &'static [u32] {
 		&[]
 	}
-	pub fn encode(self) -> ::sp_std::vec::Vec<u8> {
+	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::batch_all {
@@ -283,11 +283,11 @@ where
 		}
 	}
 }
-impl<Runtime> From<BatchPrecompileCall<Runtime>> for ::sp_std::vec::Vec<u8>
+impl<Runtime> From<BatchPrecompileCall<Runtime>> for ::alloc::vec::Vec<u8>
 where
 	Runtime: Get<u32>,
 {
-	fn from(a: BatchPrecompileCall<Runtime>) -> ::sp_std::vec::Vec<u8> {
+	fn from(a: BatchPrecompileCall<Runtime>) -> ::alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/macro/tests/expand/precompileset.expanded.rs
+++ b/precompiles/macro/tests/expand/precompileset.expanded.rs
@@ -922,7 +922,7 @@ where
 	pub fn transfer_ownership_selectors() -> &'static [u32] {
 		&[4076725131u32, 4030008324u32]
 	}
-	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
+	pub fn encode(self) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::allowance { owner, spender } => Writer::new_with_selector(3714247998u32)
@@ -1012,11 +1012,11 @@ where
 		}
 	}
 }
-impl<Runtime> From<PrecompileSetCall<Runtime>> for ::alloc::vec::Vec<u8>
+impl<Runtime> From<PrecompileSetCall<Runtime>> for ::precompile_utils::__alloc::vec::Vec<u8>
 where
 	Runtime: Get<u32>,
 {
-	fn from(a: PrecompileSetCall<Runtime>) -> ::alloc::vec::Vec<u8> {
+	fn from(a: PrecompileSetCall<Runtime>) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/macro/tests/expand/precompileset.expanded.rs
+++ b/precompiles/macro/tests/expand/precompileset.expanded.rs
@@ -922,7 +922,7 @@ where
 	pub fn transfer_ownership_selectors() -> &'static [u32] {
 		&[4076725131u32, 4030008324u32]
 	}
-	pub fn encode(self) -> ::sp_std::vec::Vec<u8> {
+	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::allowance { owner, spender } => Writer::new_with_selector(3714247998u32)
@@ -1012,11 +1012,11 @@ where
 		}
 	}
 }
-impl<Runtime> From<PrecompileSetCall<Runtime>> for ::sp_std::vec::Vec<u8>
+impl<Runtime> From<PrecompileSetCall<Runtime>> for ::alloc::vec::Vec<u8>
 where
 	Runtime: Get<u32>,
 {
-	fn from(a: PrecompileSetCall<Runtime>) -> ::sp_std::vec::Vec<u8> {
+	fn from(a: PrecompileSetCall<Runtime>) -> ::alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/macro/tests/expand/returns_tuple.expanded.rs
+++ b/precompiles/macro/tests/expand/returns_tuple.expanded.rs
@@ -72,7 +72,7 @@ impl ExamplePrecompileCall {
 	pub fn example_selectors() -> &'static [u32] {
 		&[1412775727u32]
 	}
-	pub fn encode(self) -> ::sp_std::vec::Vec<u8> {
+	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::example {} => Writer::new_with_selector(1412775727u32).build(),
@@ -82,8 +82,8 @@ impl ExamplePrecompileCall {
 		}
 	}
 }
-impl From<ExamplePrecompileCall> for ::sp_std::vec::Vec<u8> {
-	fn from(a: ExamplePrecompileCall) -> ::sp_std::vec::Vec<u8> {
+impl From<ExamplePrecompileCall> for ::alloc::vec::Vec<u8> {
+	fn from(a: ExamplePrecompileCall) -> ::alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/macro/tests/expand/returns_tuple.expanded.rs
+++ b/precompiles/macro/tests/expand/returns_tuple.expanded.rs
@@ -72,7 +72,7 @@ impl ExamplePrecompileCall {
 	pub fn example_selectors() -> &'static [u32] {
 		&[1412775727u32]
 	}
-	pub fn encode(self) -> ::alloc::vec::Vec<u8> {
+	pub fn encode(self) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		use precompile_utils::solidity::codec::Writer;
 		match self {
 			Self::example {} => Writer::new_with_selector(1412775727u32).build(),
@@ -82,8 +82,8 @@ impl ExamplePrecompileCall {
 		}
 	}
 }
-impl From<ExamplePrecompileCall> for ::alloc::vec::Vec<u8> {
-	fn from(a: ExamplePrecompileCall) -> ::alloc::vec::Vec<u8> {
+impl From<ExamplePrecompileCall> for ::precompile_utils::__alloc::vec::Vec<u8> {
+	fn from(a: ExamplePrecompileCall) -> ::precompile_utils::__alloc::vec::Vec<u8> {
 		a.encode()
 	}
 }

--- a/precompiles/src/evm/logs.rs
+++ b/precompiles/src/evm/logs.rs
@@ -17,9 +17,9 @@
 // limitations under the License.
 
 use crate::EvmResult;
+use alloc::{vec, vec::Vec};
 use pallet_evm::{Log, PrecompileHandle};
 use sp_core::{H160, H256};
-use alloc::{vec, vec::Vec};
 
 /// Create a 0-topic log.
 #[must_use]

--- a/precompiles/src/evm/logs.rs
+++ b/precompiles/src/evm/logs.rs
@@ -19,7 +19,7 @@
 use crate::EvmResult;
 use pallet_evm::{Log, PrecompileHandle};
 use sp_core::{H160, H256};
-use sp_std::{vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 
 /// Create a 0-topic log.
 #[must_use]

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -24,6 +24,11 @@ extern crate alloc;
 // `precompile_utils` being in the list of imported crates.
 extern crate self as precompile_utils;
 
+#[doc(hidden)]
+pub mod __alloc {
+	pub use ::alloc::*;
+}
+
 pub mod evm;
 pub mod precompile_set;
 pub mod substrate;

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -33,12 +33,8 @@ pub mod solidity;
 #[cfg(feature = "testing")]
 pub mod testing;
 
-use fp_evm::PrecompileFailure;
-
-// pub mod data;
-
-// pub use data::{solidity::Codec, Reader, Writer};
 pub use fp_evm::Precompile;
+use fp_evm::PrecompileFailure;
 pub use precompile_utils_macro::{keccak256, precompile, precompile_name_from_address};
 
 /// Alias for Result returning an EVM precompile error.

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -34,7 +34,8 @@ use frame_support::pallet_prelude::Get;
 use impl_trait_for_tuples::impl_for_tuples;
 use pallet_evm::AddressMapping;
 use sp_core::{H160, H256};
-use sp_std::{cell::RefCell, collections::btree_map::BTreeMap, vec, vec::Vec};
+use core::cell::RefCell;
+use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
 /// Trait representing checks that can be made on a precompile call.
 /// Types implementing this trait are made to be chained in a tuple.

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -25,7 +25,8 @@ use crate::{
 	solidity::{codec::String, revert::revert},
 	EvmResult,
 };
-use core::{marker::PhantomData, ops::RangeInclusive};
+use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
+use core::{cell::RefCell, marker::PhantomData, ops::RangeInclusive};
 use fp_evm::{
 	ExitError, IsPrecompileResult, Precompile, PrecompileFailure, PrecompileHandle,
 	PrecompileResult, PrecompileSet,
@@ -34,8 +35,6 @@ use frame_support::pallet_prelude::Get;
 use impl_trait_for_tuples::impl_for_tuples;
 use pallet_evm::AddressMapping;
 use sp_core::{H160, H256};
-use core::cell::RefCell;
-use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
 /// Trait representing checks that can be made on a precompile call.
 /// Types implementing this trait are made to be chained in a tuple.

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -25,6 +25,7 @@ use crate::{
 	solidity::{codec::String, revert::revert},
 	EvmResult,
 };
+use core::{marker::PhantomData, ops::RangeInclusive};
 use fp_evm::{
 	ExitError, IsPrecompileResult, Precompile, PrecompileFailure, PrecompileHandle,
 	PrecompileResult, PrecompileSet,
@@ -33,10 +34,7 @@ use frame_support::pallet_prelude::Get;
 use impl_trait_for_tuples::impl_for_tuples;
 use pallet_evm::AddressMapping;
 use sp_core::{H160, H256};
-use sp_std::{
-	cell::RefCell, collections::btree_map::BTreeMap, marker::PhantomData, ops::RangeInclusive, vec,
-	vec::Vec,
-};
+use sp_std::{cell::RefCell, collections::btree_map::BTreeMap, vec, vec::Vec};
 
 /// Trait representing checks that can be made on a precompile call.
 /// Types implementing this trait are made to be chained in a tuple.

--- a/precompiles/src/solidity/codec/bytes.rs
+++ b/precompiles/src/solidity/codec/bytes.rs
@@ -73,8 +73,8 @@ impl<K, S: Get<u32>> BoundedBytesString<K, S> {
 		&self.data
 	}
 
-	pub fn as_str(&self) -> Result<&str, sp_std::str::Utf8Error> {
-		sp_std::str::from_utf8(&self.data)
+	pub fn as_str(&self) -> Result<&str, core::str::Utf8Error> {
+		core::str::from_utf8(&self.data)
 	}
 }
 

--- a/precompiles/src/solidity/codec/mod.rs
+++ b/precompiles/src/solidity/codec/mod.rs
@@ -26,9 +26,9 @@ pub mod native;
 pub mod xcm;
 
 use crate::solidity::revert::{MayRevert, RevertReason};
-use core::{marker::PhantomData, ops::Range};
+use alloc::{vec, vec::Vec};
+use core::{convert::TryInto, marker::PhantomData, ops::Range};
 use sp_core::{H256, U256};
-use sp_std::{convert::TryInto, vec, vec::Vec};
 
 pub use alloc::string::String;
 pub use bytes::{BoundedBytes, BoundedString, UnboundedBytes, UnboundedString};

--- a/precompiles/src/solidity/codec/xcm.rs
+++ b/precompiles/src/solidity/codec/xcm.rs
@@ -18,11 +18,10 @@
 
 //! Encoding of XCM types for solidity
 
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 
 use frame_support::{ensure, traits::ConstU32};
 use sp_core::H256;
-use sp_std::vec::Vec;
 use sp_weights::Weight;
 use xcm::latest::{Junction, Junctions, Location, NetworkId};
 

--- a/precompiles/src/solidity/revert.rs
+++ b/precompiles/src/solidity/revert.rs
@@ -20,9 +20,11 @@
 //! consistent formatting.
 
 use crate::solidity::{self, codec::bytes::UnboundedBytes};
-use alloc::string::{String, ToString};
+use alloc::{
+	string::{String, ToString},
+	vec::Vec,
+};
 use fp_evm::{ExitRevert, PrecompileFailure};
-use sp_std::vec::Vec;
 
 /// Represent the result of a computation that can revert.
 pub type MayRevert<T = ()> = Result<T, Revert>;

--- a/precompiles/src/testing/execution.rs
+++ b/precompiles/src/testing/execution.rs
@@ -20,12 +20,12 @@ use crate::{
 	solidity::codec::Codec,
 	testing::{decode_revert_message, MockHandle, PrettyLog, SubcallHandle, SubcallTrait},
 };
+use alloc::boxed::Box;
 use fp_evm::{
 	Context, ExitError, ExitSucceed, Log, PrecompileFailure, PrecompileOutput, PrecompileResult,
 	PrecompileSet,
 };
 use sp_core::{H160, U256};
-use sp_std::boxed::Box;
 
 #[must_use]
 pub struct PrecompilesTester<'p, P> {

--- a/precompiles/src/testing/handle.rs
+++ b/precompiles/src/testing/handle.rs
@@ -17,10 +17,10 @@
 // limitations under the License.
 
 use crate::testing::PrettyLog;
+use alloc::boxed::Box;
 use evm::{ExitRevert, ExitSucceed};
 use fp_evm::{Context, ExitError, ExitReason, Log, PrecompileHandle, Transfer};
 use sp_core::{H160, H256};
-use sp_std::boxed::Box;
 
 #[derive(Debug, Clone)]
 pub struct Subcall {

--- a/precompiles/tests-external/Cargo.toml
+++ b/precompiles/tests-external/Cargo.toml
@@ -16,7 +16,6 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 # Substrate FRAME
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -18,6 +18,8 @@
 
 #![cfg(test)]
 
+extern crate alloc;
+
 use std::{cell::RefCell, rc::Rc};
 
 // Substrate

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -18,8 +18,6 @@
 
 #![cfg(test)]
 
-extern crate alloc;
-
 use std::{cell::RefCell, rc::Rc};
 
 // Substrate

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -18,6 +18,9 @@
 
 #![cfg(test)]
 
+// #[precompile_utils::precompile] need this
+extern crate alloc;
+
 use std::{cell::RefCell, rc::Rc};
 
 // Substrate

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -21,7 +21,6 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 
@@ -40,7 +39,6 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-runtime-interface/std",
-	"sp-std/std",
 ]
 serde = [
 	"dep:serde",

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -36,7 +36,7 @@ pub struct AccountId20(pub [u8; 20]);
 impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
 
 #[cfg(feature = "std")]
-impl std::str::FromStr for AccountId20 {
+impl core::str::FromStr for AccountId20 {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -47,8 +47,8 @@ impl std::str::FromStr for AccountId20 {
 }
 
 #[cfg(feature = "std")]
-impl std::fmt::Display for AccountId20 {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for AccountId20 {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		let address = hex::encode(self.0).trim_start_matches("0x").to_lowercase();
 		let address_hash = hex::encode(keccak_256(address.as_bytes()));
 
@@ -73,8 +73,8 @@ impl std::fmt::Display for AccountId20 {
 	}
 }
 
-impl sp_std::fmt::Debug for AccountId20 {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+impl core::fmt::Debug for AccountId20 {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		write!(f, "{:?}", H160(self.0))
 	}
 }
@@ -231,9 +231,8 @@ impl sp_runtime::traits::IdentifyAccount for EthereumSigner {
 	}
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Display for EthereumSigner {
-	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for EthereumSigner {
+	fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
 		write!(fmt, "{:?}", H160::from(self.0))
 	}
 }

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -13,7 +13,6 @@ scale-codec = { package = "parity-scale-codec", workspace = true }
 # Substrate
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ["std"]
@@ -23,5 +22,4 @@ std = [
 	# Substrate
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -19,13 +19,15 @@
 #![allow(clippy::large_enum_variant)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
 	generic::{Digest, OpaqueDigestItemId},
 	ConsensusEngineId,
 };
-use sp_std::vec::Vec;
 
 pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
 

--- a/primitives/ethereum/Cargo.toml
+++ b/primitives/ethereum/Cargo.toml
@@ -16,7 +16,6 @@ ethereum-types = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 # Substrate
 frame-support = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-evm = { workspace = true }
 
@@ -28,7 +27,6 @@ std = [
 	"scale-codec/std",
 	# Substrate
 	"frame-support/std",
-	"sp-std/std",
 	# Frontier
 	"fp-evm/std",
 ]

--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -18,6 +18,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::result::Result;
 pub use ethereum::{
 	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
 	TransactionAction, TransactionV2 as Transaction,
@@ -26,7 +30,6 @@ use ethereum_types::{H160, H256, U256};
 use fp_evm::{CallOrCreateInfo, CheckEvmTransactionInput};
 use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use scale_codec::{Decode, Encode};
-use sp_std::{result::Result, vec::Vec};
 
 pub trait ValidatedTransaction {
 	fn apply(

--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -21,7 +21,6 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::result::Result;
 pub use ethereum::{
 	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
 	TransactionAction, TransactionV2 as Transaction,

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -20,7 +20,6 @@ serde = { workspace = true, optional = true }
 frame-support = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ["std"]
@@ -34,7 +33,6 @@ std = [
 	"frame-support/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 serde = [
 	"dep:serde",

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -18,9 +18,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
 mod precompile;
 mod validation;
 
+use alloc::{collections::BTreeMap, vec::Vec};
 use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight};
 use scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -28,7 +31,6 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_runtime::Perbill;
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 pub use evm::{
 	backend::{Basic as Account, Log},

--- a/primitives/evm/src/precompile.rs
+++ b/primitives/evm/src/precompile.rs
@@ -15,13 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec::Vec;
 pub use evm::{
 	executor::stack::{
 		IsPrecompileResult, PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileSet,
 	},
 	Context, ExitError, ExitRevert, ExitSucceed, Transfer,
 };
-use sp_std::vec::Vec;
 
 pub type PrecompileResult = Result<PrecompileOutput, PrecompileFailure>;
 

--- a/primitives/evm/src/validation.rs
+++ b/primitives/evm/src/validation.rs
@@ -17,10 +17,10 @@
 
 #![allow(clippy::comparison_chain)]
 
+use alloc::vec::Vec;
 pub use evm::backend::Basic as Account;
 use frame_support::{sp_runtime::traits::UniqueSaturatedInto, weights::Weight};
 use sp_core::{H160, H256, U256};
-use sp_std::vec::Vec;
 
 #[derive(Debug)]
 pub struct CheckEvmTransactionInput {
@@ -51,7 +51,7 @@ pub struct CheckEvmTransaction<'config, E: From<TransactionValidationError>> {
 	pub transaction: CheckEvmTransactionInput,
 	pub weight_limit: Option<Weight>,
 	pub proof_size_base_cost: Option<u64>,
-	_marker: sp_std::marker::PhantomData<E>,
+	_marker: core::marker::PhantomData<E>,
 }
 
 /// Transaction validation errors

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -20,7 +20,6 @@ sp-api = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-state-machine = { workspace = true }
-sp-std = { workspace = true }
 # Frontier
 fp-evm = { workspace = true }
 
@@ -36,7 +35,6 @@ std = [
 	"sp-state-machine/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	# Frontier
 	"fp-evm/std",
 ]

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -19,6 +19,9 @@
 #![allow(clippy::too_many_arguments)]
 #![warn(unused_crate_dependencies)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use ethereum::Log;
 use ethereum_types::Bloom;
 use scale_codec::{Decode, Encode};
@@ -30,7 +33,6 @@ use sp_runtime::{
 	Permill, RuntimeDebug,
 };
 use sp_state_machine::OverlayedChanges;
-use sp_std::vec::Vec;
 
 #[derive(Clone, Eq, PartialEq, Default, RuntimeDebug, Encode, Decode, TypeInfo)]
 pub struct TransactionStatus {

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -26,7 +26,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
 # Substrate FRAME
@@ -80,7 +79,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -6,10 +6,14 @@
 #![allow(clippy::new_without_default, clippy::or_fun_call)]
 #![cfg_attr(feature = "runtime-benchmarks", warn(unused_crate_dependencies))]
 
+extern crate alloc;
+
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use alloc::{boxed::Box, vec::Vec};
+use core::marker::PhantomData;
 use scale_codec::{Decode, Encode};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -27,7 +31,6 @@ use sp_runtime::{
 	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResult, ConsensusEngineId, ExtrinsicInclusionMode, Perbill, Permill,
 };
-use sp_std::{marker::PhantomData, prelude::*};
 use sp_version::RuntimeVersion;
 // Substrate FRAME
 #[cfg(feature = "with-paritydb-weights")]
@@ -976,7 +979,7 @@ impl_runtime_apis! {
 			impl baseline::Config for Runtime {}
 			impl frame_system_benchmarking::Config for Runtime {}
 
-			let whitelist: Vec<TrackedStorageKey> = vec![];
+			let whitelist: Vec<TrackedStorageKey> = Vec::new();
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&config, &whitelist);

--- a/template/runtime/src/precompiles.rs
+++ b/template/runtime/src/precompiles.rs
@@ -1,8 +1,8 @@
+use core::marker::PhantomData;
 use pallet_evm::{
 	IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
 use sp_core::H160;
-use sp_std::marker::PhantomData;
 
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;


### PR DESCRIPTION
related issue: https://github.com/paritytech/polkadot-sdk/issues/2101

Now the `precompile` macro need the user importing sp-std. This PR remove this require and use alloc(no need to write `extern crate alloc`).