### PR TITLE
basefee pallet inline docs for pallet description

### DIFF
--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -15,6 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # BaseFee pallet
+//!
+//! The BaseFee pallet is responsible for managing the `BaseFeePerGas` value.
+//! This pallet can dynamically adjust the `BaseFeePerGas` by utilizing `Elasticity`.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::comparison_chain)]
 #![warn(unused_crate_dependencies)]


### PR DESCRIPTION
It's not a critical thing, but it's better to have small description/summary for each pallet in `src/lib.rs`. For example, you guys already have that for `pallet-ethereum`.

I had to check to source-code and read all the code of `basefee pallet` to understand what this pallet does just to be sure. 

Added the inline docs as a draft, feel free to change it or merge it as is.