### PR TITLE
fix: Fix FromStr not found error on AccountId20

### DIFF
--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -48,7 +48,8 @@ impl core::str::FromStr for AccountId20 {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		<[u8; 20] as hex::FromHex>::from_hex(s.strip_prefix("0x").unwrap_or(s))
+#[cfg(feature = "std")]
+impl std::str::FromStr for AccountId20 {
 			.map(Into::into)
 			.map_err(|_| "invalid hex address.")
 	}

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -48,7 +48,7 @@ impl core::str::FromStr for AccountId20 {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		H160::from_str(s)
+		<[u8; 20] as hex::FromHex>::from_hex(s.strip_prefix("0x").unwrap_or(s))
 			.map(Into::into)
 			.map_err(|_| "invalid hex address.")
 	}

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -44,12 +44,12 @@ pub struct AccountId20(pub [u8; 20]);
 #[cfg(feature = "serde")]
 impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
 
-impl core::str::FromStr for AccountId20 {
+#[cfg(feature = "std")]
+impl std::str::FromStr for AccountId20 {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-#[cfg(feature = "std")]
-impl std::str::FromStr for AccountId20 {
+		H160::from_str(s)
 			.map(Into::into)
 			.map_err(|_| "invalid hex address.")
 	}


### PR DESCRIPTION
This PR fixes the following issue.

---
When building `fp-account` without default features with the command:

```sh
cargo build -p fp-account --no-default-features --target wasm32-unknown-unknown
```

an error will occur because `core::fmt::FromStr` is not implemented for `H160` without default features.

```sh
    Checking fp-account v1.0.0-dev (/Users/conr2d/Projects/frontier/primitives/account)
error[E0599]: no function or associated item named `from_str` found for struct `H160` in the current scope
  --> primitives/account/src/lib.rs:51:9
   |
51 |         H160::from_str(s)
   |               ^^^^^^^^ function or associated item not found in `H160`
   |
```