### PR TITLE
Add client side check of withdraw-ability

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -92,6 +92,7 @@ use frame_support::{
 	},
 	weights::Weight,
 };
+use frame_support::traits::tokens::WithdrawConsequence;
 use frame_system::RawOrigin;
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
@@ -1043,6 +1044,8 @@ pub trait OnChargeEVMTransaction<T: Config> {
 	/// need to be secured.
 	fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>>;
 
+	fn can_withdraw(who: &H160, amount: U256) -> Result<(), Error<T>>;
+
 	/// After the transaction was executed the actual fee can be calculated.
 	/// This function should refund any overpaid fees and optionally deposit
 	/// the corrected amount, and handles the base fee rationing using the provided
@@ -1092,6 +1095,20 @@ where
 		)
 		.map_err(|_| Error::<T>::BalanceLow)?;
 		Ok(Some(imbalance))
+	}
+
+	fn can_withdraw(who: &H160, amount: U256) -> Result<(), Error<T>> {
+		let account_id = T::AddressMapping::into_account_id(*who);
+		let amount = amount.unique_saturated_into();
+		let new_free = C::free_balance(&account_id).saturating_sub(amount);
+		C::ensure_can_withdraw(
+			&account_id,
+			amount,
+			WithdrawReasons::FEE, // note that this is ignored in ensure_can_withdraw()
+			new_free,
+		)
+		.map_err(|_| Error::<T>::BalanceLow)?;
+		Ok(())
 	}
 
 	fn correct_and_deposit_fee(
@@ -1187,6 +1204,15 @@ where
 		Ok(Some(imbalance))
 	}
 
+	fn can_withdraw(who: &H160, amount: U256) -> Result<(), Error<T>> {
+		let account_id = T::AddressMapping::into_account_id(*who);
+		let amount = amount.unique_saturated_into();
+		if let WithdrawConsequence::Success = F::can_withdraw(&account_id, amount) {
+			return Ok(());
+		}
+		Err(Error::<T>::BalanceLow)
+	}
+
 	fn correct_and_deposit_fee(
 		who: &H160,
 		corrected_fee: U256,
@@ -1257,6 +1283,10 @@ where
 
 	fn pay_priority_fee(tip: Self::LiquidityInfo) {
 		<EVMFungibleAdapter<T::Currency, ()> as OnChargeEVMTransaction<T>>::pay_priority_fee(tip);
+	}
+
+	fn can_withdraw(who: &H160, amount: U256) -> Result<(), Error<T>> {
+		EVMFungibleAdapter::<T::Currency, ()>::can_withdraw(who, amount)
 	}
 }
 

--- a/primitives/evm/src/validation.rs
+++ b/primitives/evm/src/validation.rs
@@ -199,6 +199,14 @@ impl<'config, E: From<TransactionValidationError>> CheckEvmTransaction<'config, 
 		}
 	}
 
+	pub fn max_withdraw_amount(&self) -> Result<U256, E> {
+		Ok(self
+			.transaction_fee_input()?
+			.0 // max_fee_per_gas
+			.saturating_mul(self.transaction.gas_limit)
+			.saturating_add(self.transaction.value))
+	}
+
 	pub fn validate_common(&self) -> Result<&Self, E> {
 		if self.config.is_transactional {
 			// Try to subtract the proof_size_base_cost from the Weight proof_size limit or fail.


### PR DESCRIPTION
This pull request introduces changes to the `frame/ethereum` and `frame/evm` modules to improve transaction validation and add a new method for checking the maximum withdrawable amount on the client side.