### PR TITLE
Include best block hash in syncing tips

### DIFF
--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -176,11 +176,7 @@ where
 	}
 
 	let best_hash = client.info().best_hash;
-	if SyncStrategy::Parachain == strategy
-		&& !frontier_backend
-			.mapping()
-			.is_synced(&best_hash)?
-	{
+	if SyncStrategy::Parachain == strategy && !frontier_backend.mapping().is_synced(&best_hash)? {
 		// Add best block to current_syncing_tips
 		current_syncing_tips.push(best_hash);
 	}

--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -175,6 +175,16 @@ where
 		current_syncing_tips.append(&mut leaves);
 	}
 
+	let best_hash = client.info().best_hash;
+	if SyncStrategy::Parachain == strategy
+		&& !frontier_backend
+			.mapping()
+			.is_synced(&best_hash)?
+	{
+		// Add best block to current_syncing_tips
+		current_syncing_tips.push(best_hash);
+	}
+
 	let mut operating_header = None;
 	while let Some(checking_tip) = current_syncing_tips.pop() {
 		if let Some(checking_header) = fetch_header(


### PR DESCRIPTION
Fix to a delay issue in syncing the best block in MappingDB in Parachain mode, which caused `eth_getBlockByHash` not to work for HEAD.

This pull request includes a change to the `client/mapping-sync/src/kv/mod.rs` file to improve the synchronization process by adding the best block to the current syncing tips if it is not already synced.