### PR TITLE
Ignore user provided nonce when estimating gas

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -560,7 +560,6 @@ where
 					gas,
 					value,
 					data,
-					nonce,
 					access_list,
 					..
 				} = request;
@@ -583,7 +582,7 @@ where
 								value.unwrap_or_default(),
 								gas_limit,
 								gas_price,
-								nonce,
+								None,
 								estimate_mode,
 							)
 							.map_err(|err| internal_err(format!("runtime error: {err}")))?
@@ -602,7 +601,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 							)
 							.map_err(|err| internal_err(format!("runtime error: {err}")))?
@@ -622,7 +621,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 								Some(
 									access_list
@@ -647,7 +646,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 								Some(
 									access_list
@@ -673,7 +672,7 @@ where
 								value.unwrap_or_default(),
 								gas_limit,
 								gas_price,
-								nonce,
+								None,
 								estimate_mode,
 							)
 							.map_err(|err| internal_err(format!("runtime error: {err}")))?
@@ -691,7 +690,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 							)
 							.map_err(|err| internal_err(format!("runtime error: {err}")))?
@@ -710,7 +709,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 								Some(
 									access_list
@@ -734,7 +733,7 @@ where
 								gas_limit,
 								max_fee_per_gas,
 								max_priority_fee_per_gas,
-								nonce,
+								None,
 								estimate_mode,
 								Some(
 									access_list

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -132,6 +132,15 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 		expect(result).to.equal(197732);
 	});
 
+	it("eth_estimateGas should ignore nonce", async function () {
+		let result = await context.web3.eth.estimateGas({
+			from: GENESIS_ACCOUNT,
+			data: Test.bytecode,
+			nonce: 42, // Arbitrary nonce value
+		});
+		expect(result).to.equal(197732);
+	});
+
 	it("tx gas limit below ETH_BLOCK_GAS_LIMIT", async function () {
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{


### PR DESCRIPTION
The RPC method `eth_estimateGas` takes a Transaction object with a nonce field, the client requires that this nonce is equal to the current on-chain user nonce + 1. This a discrepancy with `geth` behavior, which always ignores the nonce field. Now, the field is still there to not break the RPC api but not used.