### PR TITLE
Add backend method first_block_hash

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -53,6 +53,9 @@ pub trait Backend<Block: BlockT>: Send + Sync {
 		self.log_indexer().is_indexed()
 	}
 
+	/// Get the hash of the oldest substrate block fully indexed by the backend.
+	async fn first_block_hash(&self) -> Result<Block::Hash, String>;
+
 	/// Get the hash of the latest substrate block fully indexed by the backend.
 	async fn latest_block_hash(&self) -> Result<Block::Hash, String>;
 }

--- a/client/db/src/kv/mod.rs
+++ b/client/db/src/kv/mod.rs
@@ -90,6 +90,10 @@ impl<Block: BlockT, C: HeaderBackend<Block>> fc_api::Backend<Block> for Backend<
 		&self.log_indexer
 	}
 
+	async fn first_block_hash(&self) -> Result<Block::Hash, String> {
+		Ok(self.client.info().genesis_hash)
+	}
+
 	async fn latest_block_hash(&self) -> Result<Block::Hash, String> {
 		Ok(self.client.info().best_hash)
 	}

--- a/client/db/src/sql/mod.rs
+++ b/client/db/src/sql/mod.rs
@@ -820,6 +820,15 @@ impl<Block: BlockT<Hash = H256>> fc_api::Backend<Block> for Backend<Block> {
 		self
 	}
 
+	async fn first_block_hash(&self) -> Result<Block::Hash, String> {
+		// Retrieves the block hash for the latest indexed block, maybe it's not canon.
+		sqlx::query("SELECT substrate_block_hash FROM blocks ORDER BY block_number ASC LIMIT 1")
+			.fetch_one(self.pool())
+			.await
+			.map(|row| H256::from_slice(&row.get::<Vec<u8>, _>(0)[..]))
+			.map_err(|e| format!("Failed to fetch oldest block hash: {}", e))
+	}
+
 	async fn latest_block_hash(&self) -> Result<Block::Hash, String> {
 		// Retrieves the block hash for the latest indexed block, maybe it's not canon.
 		sqlx::query("SELECT substrate_block_hash FROM blocks ORDER BY block_number DESC LIMIT 1")

--- a/client/db/src/sql/mod.rs
+++ b/client/db/src/sql/mod.rs
@@ -821,7 +821,7 @@ impl<Block: BlockT<Hash = H256>> fc_api::Backend<Block> for Backend<Block> {
 	}
 
 	async fn first_block_hash(&self) -> Result<Block::Hash, String> {
-		// Retrieves the block hash for the latest indexed block, maybe it's not canon.
+		// Retrieves the block hash for the earliest indexed block, maybe it's not canon.
 		sqlx::query("SELECT substrate_block_hash FROM blocks ORDER BY block_number ASC LIMIT 1")
 			.fetch_one(self.pool())
 			.await


### PR DESCRIPTION
This pull request introduces a new method to fetch the hash of the first substrate block in the backend. This will enables the ability to get the range of blocks that are fully indexed in frontier's backend.  
