### PR TITLE
Fix: propagate OOG from PoV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,7 @@ dependencies = [
 name = "fp-evm"
 version = "3.0.0-dev"
 dependencies = [
+ "environmental",
  "evm",
  "frame-support",
  "num_enum",

--- a/frame/evm/src/runner/meter.rs
+++ b/frame/evm/src/runner/meter.rs
@@ -50,12 +50,13 @@ impl StorageMeter {
 	/// Records the given amount of storage usage. The amount is added to the current usage.
 	/// If the limit is reached, an error is returned.
 	pub fn record(&mut self, amount: u64) -> Result<(), MeterError> {
-		let usage = self
-			.usage
-			.checked_add(amount)
-			.ok_or(MeterError::LimitExceeded)?;
+		let usage = self.usage.checked_add(amount).ok_or_else(|| {
+			fp_evm::set_storage_oog();
+			MeterError::LimitExceeded
+		})?;
 
 		if usage > self.limit {
+			fp_evm::set_storage_oog();
 			return Err(MeterError::LimitExceeded);
 		}
 		self.usage = usage;

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -262,7 +262,6 @@ where
 		let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)
 			.map_err(|e| RunnerError { error: e, weight })?;
 
-		// Execute the EVM call.
 		let vicinity = Vicinity {
 			gas_price: base_fee,
 			origin: source,
@@ -281,28 +280,34 @@ where
 		let state = SubstrateStackState::new(&vicinity, metadata, maybe_weight_info, storage_limit);
 		let mut executor = StackExecutor::new_with_precompiles(state, config, precompiles);
 
-		let (reason, retv) = f(&mut executor);
+		// Execute the EVM call.
+		let (reason, retv, used_gas, effective_gas) =
+			fp_evm::handle_storage_oog::<R, _>(gas_limit, || {
+				let (reason, retv) = f(&mut executor);
 
-		// Compute the storage gas cost based on the storage growth.
-		let storage_gas = match &executor.state().storage_meter {
-			Some(storage_meter) => storage_meter.storage_to_gas(storage_growth_ratio),
-			None => 0,
-		};
+				// Compute the storage gas cost based on the storage growth.
+				let storage_gas = match &executor.state().storage_meter {
+					Some(storage_meter) => storage_meter.storage_to_gas(storage_growth_ratio),
+					None => 0,
+				};
 
-		let pov_gas = match executor.state().weight_info() {
-			Some(weight_info) => weight_info
-				.proof_size_usage
-				.unwrap_or_default()
-				.saturating_mul(T::GasLimitPovSizeRatio::get()),
-			None => 0,
-		};
+				let pov_gas = match executor.state().weight_info() {
+					Some(weight_info) => weight_info
+						.proof_size_usage
+						.unwrap_or_default()
+						.saturating_mul(T::GasLimitPovSizeRatio::get()),
+					None => 0,
+				};
 
-		// Post execution.
-		let used_gas = executor.used_gas();
-		let effective_gas = U256::from(core::cmp::max(
-			core::cmp::max(used_gas, pov_gas),
-			storage_gas,
-		));
+				// Post execution.
+				let used_gas = executor.used_gas();
+				let effective_gas = U256::from(core::cmp::max(
+					core::cmp::max(used_gas, pov_gas),
+					storage_gas,
+				));
+
+				(reason, retv, used_gas, effective_gas)
+			});
 
 		let actual_fee = effective_gas.saturating_mul(total_fee_per_gas);
 		let actual_base_fee = effective_gas.saturating_mul(base_fee);
@@ -1038,6 +1043,7 @@ where
 
 							let actual_size = Pallet::<T>::account_code_metadata(address).size;
 							if actual_size > pre_size {
+								fp_evm::set_storage_oog();
 								return Err(ExitError::OutOfGas);
 							}
 							// Refund unused proof size

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -11,8 +11,8 @@ repository = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-evm = { workspace = true, features = ["with-codec"] }
 environmental = { workspace = true }
+evm = { workspace = true, features = ["with-codec"] }
 num_enum = { workspace = true, default-features = false }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -12,10 +12,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 evm = { workspace = true, features = ["with-codec"] }
+environmental = { workspace = true }
 num_enum = { workspace = true, default-features = false }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
+
 # Substrate
 frame-support = { workspace = true }
 sp-core = { workspace = true }
@@ -26,6 +28,7 @@ default = ["std"]
 std = [
 	"evm/std",
 	"evm/with-serde",
+	"environmental/std",
 	"num_enum/std",
 	"serde/std",
 	"scale-codec/std",

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -22,6 +22,7 @@ extern crate alloc;
 
 mod account_provider;
 mod precompile;
+mod storage_oog;
 mod validation;
 
 use alloc::{collections::BTreeMap, vec::Vec};
@@ -45,6 +46,7 @@ pub use self::{
 		Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileResult,
 		PrecompileSet, Transfer,
 	},
+	storage_oog::{handle_storage_oog, set_storage_oog},
 	validation::{
 		CheckEvmTransaction, CheckEvmTransactionConfig, CheckEvmTransactionInput,
 		TransactionValidationError,
@@ -118,6 +120,7 @@ impl WeightInfo {
 	fn try_consume(&self, cost: u64, limit: u64, usage: u64) -> Result<u64, ExitError> {
 		let usage = usage.checked_add(cost).ok_or(ExitError::OutOfGas)?;
 		if usage > limit {
+			storage_oog::set_storage_oog();
 			return Err(ExitError::OutOfGas);
 		}
 		Ok(usage)
@@ -142,6 +145,7 @@ impl WeightInfo {
 		{
 			let proof_size_usage = self.try_consume(cost, proof_size_limit, proof_size_usage)?;
 			if proof_size_usage > proof_size_limit {
+				storage_oog::set_storage_oog();
 				return Err(ExitError::OutOfGas);
 			}
 			self.proof_size_usage = Some(proof_size_usage);

--- a/primitives/evm/src/storage_oog.rs
+++ b/primitives/evm/src/storage_oog.rs
@@ -1,0 +1,52 @@
+// This file is part of Frontier.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+environmental::environmental!(STORAGE_OOG: bool);
+
+use crate::{ExitError, ExitReason};
+use sp_core::U256;
+
+pub fn handle_storage_oog<R, F>(gas_limit: u64, f: F) -> (ExitReason, R, u64, U256)
+where
+	F: FnOnce() -> (ExitReason, R, u64, U256),
+	R: Default,
+{
+	STORAGE_OOG::using_once(&mut false, || {
+		let (reason, retv, used_gas, effective_gas) = f();
+
+		STORAGE_OOG::with(|storage_oog| {
+			if *storage_oog {
+				(
+					ExitReason::Error(ExitError::OutOfGas),
+					Default::default(),
+					used_gas,
+					U256([gas_limit, 0, 0, 0]),
+				)
+			} else {
+				(reason, retv, used_gas, effective_gas)
+			}
+		})
+		// This should always return `Some`, but let's play it safe.
+		.expect("STORAGE_OOG not defined")
+	})
+}
+
+pub fn set_storage_oog() {
+	STORAGE_OOG::with(|storage_oog| {
+		*storage_oog = true;
+	});
+}


### PR DESCRIPTION
Fixes issue where a TX that reaches out of gas due to PoV costs would revert without propagating a proper OOG error