### PR TITLE
Fine-grained `Pending` state

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -255,7 +255,8 @@ pub mod pallet {
 					UniqueSaturatedInto::<u32>::unique_saturated_into(to_remove),
 				));
 			}
-			Pending::<T>::kill();
+			// Reset the next transaction index
+			NextTxIndex::<T>::set(0);
 		}
 
 		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
@@ -348,10 +349,14 @@ pub mod pallet {
 		PreLogExists,
 	}
 
-	/// Current building block's transactions and receipts.
+	/// The next transcation index.
+	#[pallet::storage]
+	pub type NextTxIndex<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	/// Mapping from transaction index to transaction in the current building block.
 	#[pallet::storage]
 	pub type Pending<T: Config> =
-		StorageValue<_, Vec<(Transaction, TransactionStatus, Receipt)>, ValueQuery>;
+		StorageMap<_, Identity, u32, (Transaction, TransactionStatus, Receipt), OptionQuery>;
 
 	/// The current Ethereum block.
 	#[pallet::storage]
@@ -441,17 +446,19 @@ impl<T: Config> Pallet<T> {
 		let mut receipts = Vec::new();
 		let mut logs_bloom = Bloom::default();
 		let mut cumulative_gas_used = U256::zero();
-		for (transaction, status, receipt) in Pending::<T>::get() {
-			transactions.push(transaction);
-			statuses.push(status);
-			receipts.push(receipt.clone());
-			let (logs, used_gas) = match receipt {
-				Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => {
-					(d.logs.clone(), d.used_gas)
-				}
-			};
-			cumulative_gas_used = used_gas;
-			Self::logs_bloom(logs, &mut logs_bloom);
+		for tx_index in 0..NextTxIndex::<T>::get() {
+			if let Some((transaction, status, receipt)) = Pending::<T>::take(tx_index) {
+				transactions.push(transaction);
+				statuses.push(status);
+				receipts.push(receipt.clone());
+				let (logs, used_gas) = match receipt {
+					Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => {
+						(d.logs.clone(), d.used_gas)
+					}
+				};
+				cumulative_gas_used = used_gas;
+				Self::logs_bloom(logs, &mut logs_bloom);
+			}
 		}
 
 		let ommers = Vec::<ethereum::Header>::new();
@@ -597,9 +604,8 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(PostDispatchInfo, CallOrCreateInfo), DispatchErrorWithPostInfo> {
 		let (to, _, info) = Self::execute(source, &transaction, None)?;
 
-		let pending = Pending::<T>::get();
 		let transaction_hash = transaction.hash();
-		let transaction_index = pending.len() as u32;
+		let transaction_index = NextTxIndex::<T>::get();
 
 		let (reason, status, weight_info, used_gas, dest, extra_data) = match info.clone() {
 			CallOrCreateInfo::Call(info) => (
@@ -675,7 +681,9 @@ impl<T: Config> Pallet<T> {
 			};
 			let logs_bloom = status.logs_bloom;
 			let logs = status.clone().logs;
-			let cumulative_gas_used = if let Some((_, _, receipt)) = pending.last() {
+			let cumulative_gas_used = if let Some((_, _, receipt)) =
+				Pending::<T>::get(transaction_index.saturating_sub(1))
+			{
 				match receipt {
 					Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => {
 						d.used_gas.saturating_add(used_gas.effective)
@@ -706,7 +714,8 @@ impl<T: Config> Pallet<T> {
 			}
 		};
 
-		Pending::<T>::append((transaction, status, receipt));
+		Pending::<T>::insert(transaction_index, (transaction, status, receipt));
+		NextTxIndex::<T>::set(transaction_index + 1);
 
 		Self::deposit_event(Event::Executed {
 			from: source,


### PR DESCRIPTION
The `Pending` state is a list that is used to keep track of all the `(transaction, status, receipt)` in the block during block execution, and then in `on_finalize` these data are moved to `CurrentBlock/CurrentReceipts/CurrentTransactionStatuses` for RPC service usage.

Because the `Pending` state is a `StorageValue<_, Vec<...>>`, which presents as a single value in the trie, appending items to the list means read,update,write to the same value, which gets slower and slower as the list grows during block execution, and depend on the number of tx in the block it can result in 3-20x of slow (see below).

This PR fixes the issue by refactoring the `Pending` state, to replace `StorageValue` with `StorageMap` so each tx is present as a single value in the trie, although it results in more db delete in `on_finalize` but in practice, it is much faster than updating a big single list.

Below is a table about the block execution time of different `Pending` states where `N` represents the total number of `Ethereum::transact` in the block, each tx transfers funds from the same `Alice` account to a new different account. The test is running on a `MacBook Pro, Apple M1 Pro, 10 Core(s)`

Tx in block | N = 1000 | N = 2000 | N = 4000 | N = 5000 | N = 6000 | N = 8000
-- | -- | -- | -- | -- | -- | --
Current `Pending` state | 690ms | 2_498ms | 9_493ms | 14_921ms | 21_383ms | 37_426ms
No `Pending` state | 194ms | 382ms | 780ms | 1_047ms | 1_187ms | 1_596ms
Fine-grained `Pending` state | 221ms | 449ms | 869ms | 1_103ms | 1_329ms | 1_772ms

