### PR TITLE
Typo fix mod.rs

### DIFF
--- a/frame/ethereum/src/tests/mod.rs
+++ b/frame/ethereum/src/tests/mod.rs
@@ -19,7 +19,7 @@ use frame_support::{
 	assert_err, assert_ok, dispatch::GetDispatchInfo, unsigned::TransactionValidityError,
 };
 use sp_runtime::{
-	traits::Applyable,
+	traits::Applicable,
 	transaction_validity::{InvalidTransaction, ValidTransactionBuilder},
 };
 use std::str::FromStr;


### PR DESCRIPTION
# Pull Request: Typo Fix in `mod.rs`

## Description
This pull request addresses a typo in the `mod.rs` file, specifically correcting `Applyable` to `Applicable`.

---

### Changes Made
1. **File Updated:** `frame/ethereum/src/tests/mod.rs`
2. **Line Modified:**
   - Original: `traits::Applyable,`
   - Updated: `traits::Applicable,`

---

