### PR TITLE
feat: Make fc-rpc dependencies on aura crates optional

### DIFF
--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -24,14 +24,14 @@ rand = "0.8"
 rlp = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 schnellru = "0.2.3"
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 # Substrate
 prometheus-endpoint = { workspace = true }
 sc-client-api = { workspace = true }
-sc-consensus-aura = { workspace = true }
+sc-consensus-aura = { workspace = true, optional = true }
 sc-network = { workspace = true }
 sc-network-sync = { workspace = true }
 sc-rpc = { workspace = true }
@@ -43,7 +43,7 @@ sp-api = { workspace = true, features = ["default"] }
 sp-block-builder = { workspace = true, features = ["default"] }
 sp-blockchain = { workspace = true }
 sp-consensus = { workspace = true }
-sp-consensus-aura = { workspace = true, features = ["default"] }
+sp-consensus-aura = { workspace = true, features = ["default"], optional = true }
 sp-core = { workspace = true, features = ["default"] }
 sp-externalities = { workspace = true, features = ["default"] }
 sp-inherents = { workspace = true, features = ["default"] }
@@ -51,7 +51,7 @@ sp-io = { workspace = true, features = ["default"] }
 sp-runtime = { workspace = true, features = ["default"] }
 sp-state-machine = { workspace = true, features = ["default"] }
 sp-storage = { workspace = true, features = ["default"] }
-sp-timestamp = { workspace = true, features = ["default"] }
+sp-timestamp = { workspace = true, features = ["default"], optional = true }
 # Frontier
 fc-api = { workspace = true }
 fc-mapping-sync = { workspace = true }
@@ -73,11 +73,16 @@ substrate-test-runtime-client = { workspace = true }
 fc-db = { workspace = true }
 
 [features]
-default = ["rocksdb"]
+default = ["aura", "rocksdb"]
+aura = [
+	"sc-consensus-aura",
+	"sp-consensus-aura",
+	"sp-timestamp",
+]
 rocksdb = [
 	"sc-service/rocksdb",
 	"fc-db/rocksdb",
 	"fc-mapping-sync/rocksdb",
 ]
-txpool = ["fc-rpc-core/txpool"]
+txpool = ["fc-rpc-core/txpool", "serde"]
 rpc-binary-search-estimate = []

--- a/client/rpc/src/eth/pending.rs
+++ b/client/rpc/src/eth/pending.rs
@@ -16,13 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{marker::PhantomData, sync::Arc};
-
 // Substrate
-use sc_client_api::{
-	backend::{AuxStore, Backend, StorageProvider},
-	UsageProvider,
-};
+use sc_client_api::backend::{Backend, StorageProvider};
 use sc_transaction_pool::ChainApi;
 use sc_transaction_pool_api::InPoolTransaction;
 use sp_api::{ApiExt, ApiRef, Core, ProvideRuntimeApi};
@@ -30,11 +25,10 @@ use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{ApplyExtrinsicFailed, HeaderBackend};
 use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
 use sp_runtime::{
-	generic::{Digest, DigestItem},
+	generic::Digest,
 	traits::{Block as BlockT, Header as HeaderT, One},
 	TransactionOutcome,
 };
-use sp_timestamp::TimestampInherentData;
 
 use crate::eth::Eth;
 use fp_rpc::EthereumRuntimeRPCApi;
@@ -169,14 +163,20 @@ impl<B: BlockT> ConsensusDataProvider<B> for () {
 	}
 }
 
+#[cfg(feature = "aura")]
 pub use self::aura::AuraConsensusDataProvider;
+#[cfg(feature = "aura")]
 mod aura {
 	use super::*;
+	use sc_client_api::{AuxStore, UsageProvider};
 	use sp_consensus_aura::{
 		digests::CompatibleDigestItem,
 		sr25519::{AuthorityId, AuthoritySignature},
 		AuraApi, Slot, SlotDuration,
 	};
+	use sp_runtime::generic::DigestItem;
+	use sp_timestamp::TimestampInherentData;
+	use std::{marker::PhantomData, sync::Arc};
 
 	/// Consensus data provider for Aura.
 	pub struct AuraConsensusDataProvider<B, C> {


### PR DESCRIPTION
Close #1514.

This PR makes the `fc-rpc` dependencies on Aura consensus-specific crates optional.