### PR TITLE
docs: correct typos

### DIFF
--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -217,7 +217,7 @@ where
 			.write_current_syncing_tips(current_syncing_tips)?;
 	}
 	// Notify on import and remove closed channels.
-	// Only notify when the node is node in major syncing.
+	// Only notify when the node is not in major syncing.
 	let sinks = &mut pubsub_notification_sinks.lock();
 	sinks.retain(|sink| {
 		if !sync_oracle.is_major_syncing() {

--- a/client/rpc-core/src/debug.rs
+++ b/client/rpc-core/src/debug.rs
@@ -39,7 +39,7 @@ pub trait DebugApi {
 	#[method(name = "debug_getRawTransaction")]
 	async fn raw_transaction(&self, hash: H256) -> RpcResult<Option<Bytes>>;
 
-	/// Returns an array of EIP-2718 binary-encoded receipts with the given number of hash.
+	/// Returns an array of EIP-2718 binary-encoded receipts with the given number or hash.
 	#[method(name = "debug_getRawReceipts")]
 	async fn raw_receipts(&self, number: BlockNumberOrHash) -> RpcResult<Vec<Bytes>>;
 

--- a/client/rpc-v2/api/src/eth/mod.rs
+++ b/client/rpc-v2/api/src/eth/mod.rs
@@ -178,7 +178,7 @@ pub trait EthExecuteApi {
 		// block_overrides: Option<BlockOverrides>,
 	) -> RpcResult<Bytes>;
 
-	/// Generates and returns an estimate of hou much gas is necessary to allow the transaction to complete.
+	/// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
 	#[method(name = "estimateGas")]
 	async fn estimate_gas(
 		&self,


### PR DESCRIPTION
- **client/mapping-sync/src/kv/mod.rs**: Fixed typo: `node is node in` → `node is not in`.  
- **client/rpc-core/src/debug.rs**: Fixed typo: `number of hash` → `number or hash`.  
- **client/rpc-v2/api/src/eth/mod.rs**: Fixed typo: `hou much` → `how much`.  
