### PR TITLE
fix: Not able to get integer (uint) log for in revert

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -975,6 +975,12 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> RpcResult
 			const MESSAGE_START: usize = 68;
 
 			let mut message = "VM Exception while processing transaction: revert".to_string();
+			let reason_uint = U256::from(&data[4..36]);
+			let offset :U256 = U256::from(32);
+
+			if data.len() == LEN_START {
+				message = format!("{message}: {}", reason_uint);
+			}
 			// A minimum size of error function selector (4) + offset (32) + string length (32)
 			// should contain a utf-8 encoded revert reason.
 			if data.len() > MESSAGE_START {
@@ -985,7 +991,12 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> RpcResult
 				if data.len() >= message_end {
 					let body: &[u8] = &data[MESSAGE_START..message_end];
 					if let Ok(reason) = std::str::from_utf8(body) {
-						message = format!("{message} {reason}");
+						if reason_uint < offset {
+							message = format!("{message} {reason_uint} {reason}");
+						}
+						else {
+						message = format!("{message}{reason}");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Earlier, I was deploying ERC 4337 account abstraction entry point contract (version 6) and it has function simulateValidation that reverts ValidationResult and has uint data type, while calling this function I am unable to get the values in ValidationResult due to which my dapp is stuck at that point. 

But now I've made a solutions for this. 

This PR enhances the revert handling logic by adding support for decoding and handling multiple custom error selectors in Solidity revert statements. 