### PR TITLE
fix: handle invalid high bits in ECRecover v value

### DIFF
--- a/frame/evm/precompile/simple/src/lib.rs
+++ b/frame/evm/precompile/simple/src/lib.rs
@@ -56,8 +56,8 @@ impl LinearCostPrecompile for ECRecover {
 		sig[32..64].copy_from_slice(&input[96..128]); // s
 		sig[64] = input[63]; // v
 
-		// v can only be 27 or 28 on the full 32 bytes value.
-		// https://github.com/ethereum/go-ethereum/blob/a907d7e81aaeea15d80b2d3209ad8e08e3bf49e0/core/vm/contracts.go#L177
+		// Check if any high bits are set in v value (bytes 32-62 must be 0)
+		// and v (byte 63) can only be 27 or 28
 		if input[32..63] != [0u8; 31] || ![27, 28].contains(&input[63]) {
 			return Ok((ExitSucceed::Returned, [0u8; 0].to_vec()));
 		}


### PR DESCRIPTION

The ECRecover precompile was already returning an empty vector for invalid v values, but the comment wasn't clear about handling high bits. This commit updates the comment to be more explicit about checking for any set high bits in the v value (bytes 32-62 must be 0) and that v (byte 63) can only be 27 or 28.

Fixes TODO comment regarding "InvalidHighV-bits-1" test case.