### PR TITLE
chore: Enable "aura" feature in fc-rpc for template node

### DIFF
--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -71,7 +71,7 @@ fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }
 fc-mapping-sync = { workspace = true }
-fc-rpc = { workspace = true }
+fc-rpc = { workspace = true, features = ["aura"] }
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }
 fp-account = { workspace = true }


### PR DESCRIPTION
In #1580, the Aura consensus implementation in `fc-rpc` was made feature-gated by the "aura" flag. Since default features are disabled for `fc-rpc`, the Frontier template node now requires the aura feature to be explicitly enabled.