### PR TITLE
Implement solidity codecs on xcm::latest

### DIFF
--- a/precompiles/src/solidity/codec/xcm.rs
+++ b/precompiles/src/solidity/codec/xcm.rs
@@ -23,7 +23,7 @@ use alloc::{string::String, vec::Vec};
 use frame_support::{ensure, traits::ConstU32};
 use sp_core::H256;
 use sp_weights::Weight;
-use xcm::lts::{Junction, Junctions, Location, NetworkId};
+use xcm::latest::{Junction, Junctions, Location, NetworkId};
 
 use crate::solidity::{
 	codec::{bytes::*, Codec, Reader, Writer},
@@ -76,6 +76,7 @@ pub(crate) fn network_id_to_bytes(network_id: Option<NetworkId>) -> Vec<u8> {
 			encoded.append(&mut block_hash.into());
 			encoded
 		}
+		/*
 		Some(NetworkId::Westend) => {
 			encoded.push(5u8);
 			encoded.push(4u8);
@@ -91,6 +92,7 @@ pub(crate) fn network_id_to_bytes(network_id: Option<NetworkId>) -> Vec<u8> {
 			encoded.push(6u8);
 			encoded
 		}
+		*/
 		Some(NetworkId::Ethereum { chain_id }) => {
 			encoded.push(8u8);
 			encoded.push(7u8);
@@ -152,9 +154,11 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> MayRevert<Option<
 				block_hash,
 			}))
 		}
+		/*
 		5 => Ok(Some(NetworkId::Westend)),
 		6 => Ok(Some(NetworkId::Rococo)),
 		7 => Ok(Some(NetworkId::Wococo)),
+		*/
 		8 => {
 			let mut chain_id: [u8; 8] = Default::default();
 			chain_id.copy_from_slice(encoded_network_id.read_raw_bytes(8)?);

--- a/precompiles/src/solidity/codec/xcm.rs
+++ b/precompiles/src/solidity/codec/xcm.rs
@@ -23,7 +23,10 @@ use alloc::{string::String, vec::Vec};
 use frame_support::{ensure, traits::ConstU32};
 use sp_core::H256;
 use sp_weights::Weight;
-use xcm::latest::{Junction, Junctions, Location, NetworkId};
+use xcm::{
+	latest::{Junction, Junctions, Location, NetworkId},
+	v5::{ROCOCO_GENESIS_HASH, WESTEND_GENESIS_HASH},
+};
 
 use crate::solidity::{
 	codec::{bytes::*, Codec, Reader, Writer},
@@ -137,6 +140,9 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> MayRevert<Option<
 				block_hash,
 			}))
 		}
+		5 => Ok(Some(NetworkId::ByGenesis(WESTEND_GENESIS_HASH))),
+		6 => Ok(Some(NetworkId::ByGenesis(ROCOCO_GENESIS_HASH))),
+		7 => Err(RevertReason::custom("Wococo Network is no longer supported").into()),
 		8 => {
 			let mut chain_id: [u8; 8] = Default::default();
 			chain_id.copy_from_slice(encoded_network_id.read_raw_bytes(8)?);

--- a/precompiles/src/solidity/codec/xcm.rs
+++ b/precompiles/src/solidity/codec/xcm.rs
@@ -76,23 +76,6 @@ pub(crate) fn network_id_to_bytes(network_id: Option<NetworkId>) -> Vec<u8> {
 			encoded.append(&mut block_hash.into());
 			encoded
 		}
-		/*
-		Some(NetworkId::Westend) => {
-			encoded.push(5u8);
-			encoded.push(4u8);
-			encoded
-		}
-		Some(NetworkId::Rococo) => {
-			encoded.push(6u8);
-			encoded.push(5u8);
-			encoded
-		}
-		Some(NetworkId::Wococo) => {
-			encoded.push(7u8);
-			encoded.push(6u8);
-			encoded
-		}
-		*/
 		Some(NetworkId::Ethereum { chain_id }) => {
 			encoded.push(8u8);
 			encoded.push(7u8);
@@ -154,11 +137,6 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> MayRevert<Option<
 				block_hash,
 			}))
 		}
-		/*
-		5 => Ok(Some(NetworkId::Westend)),
-		6 => Ok(Some(NetworkId::Rococo)),
-		7 => Ok(Some(NetworkId::Wococo)),
-		*/
 		8 => {
 			let mut chain_id: [u8; 8] = Default::default();
 			chain_id.copy_from_slice(encoded_network_id.read_raw_bytes(8)?);


### PR DESCRIPTION
**Motivation**
- Downstream dependencies (e.g., `moonkit`) depend on this behavior.
- `/primitives/account/src/lib.rs` already targets `xcm::latest`.

**Suggested Solution**
- Implement solidity codecs on `xcm::latest`.

**Alternative Solution**
- Add feature flag to support both `xcm::lts` and `xcm::latest`.
