### PR TITLE
Consume all available gas when gas limit has been reached

### DIFF
--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -130,8 +130,15 @@ impl WeightInfo {
 		if let (Some(ref_time_usage), Some(ref_time_limit)) =
 			(self.ref_time_usage, self.ref_time_limit)
 		{
-			let ref_time_usage = self.try_consume(cost, ref_time_limit, ref_time_usage)?;
-			self.ref_time_usage = Some(ref_time_usage);
+			match self.try_consume(cost, ref_time_limit, ref_time_usage) {
+				Ok(ref_time_usage) => {
+					self.ref_time_usage = Some(ref_time_usage);
+				}
+				Err(e) => {
+					self.ref_time_usage = Some(ref_time_limit);
+					return Err(e);
+				}
+			}
 		}
 		Ok(())
 	}
@@ -140,8 +147,15 @@ impl WeightInfo {
 		if let (Some(proof_size_usage), Some(proof_size_limit)) =
 			(self.proof_size_usage, self.proof_size_limit)
 		{
-			let proof_size_usage = self.try_consume(cost, proof_size_limit, proof_size_usage)?;
-			self.proof_size_usage = Some(proof_size_usage);
+			match self.try_consume(cost, proof_size_limit, proof_size_usage) {
+				Ok(proof_size_usage) => {
+					self.proof_size_usage = Some(proof_size_usage);
+				}
+				Err(e) => {
+					self.proof_size_usage = Some(proof_size_limit);
+					return Err(e);
+				}
+			}
 		}
 		Ok(())
 	}


### PR DESCRIPTION
## What does it do?

Fixes an issue where `ref_time_usage` and `proof_size_usage` were not being updated when the limits where reached.

This is not a big issue since the check was still propagating the expected `OutOfGas` error, it was just giving a false under-estimation at the end.