### PR TITLE
Feat: use SlowAdjustingFeeUpdate to update fees based on congestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "hash-db",
  "log",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2592,6 +2592,37 @@ name = "enum-ordinalize-derive"
 version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3192,7 +3223,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3321,8 +3352,8 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+version = "40.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3345,8 +3376,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+version = "47.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3418,9 +3449,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-solution-type"
+version = "16.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "frame-election-provider-support"
+version = "40.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-election-provider-solution-type",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections",
+ "sp-runtime",
+]
+
+[[package]]
 name = "frame-executive"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3462,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3478,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3519,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "33.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3539,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
@@ -3551,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3561,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3580,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3594,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3604,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3712,6 +3770,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "polkadot-runtime-common",
  "scale-info",
  "sp-api",
  "sp-block-builder",
@@ -6709,9 +6768,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pallet-asset-conversion"
+version = "22.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-asset-rate"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-aura"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6725,9 +6816,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-authority-discovery"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-authority-discovery",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-authorship"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6740,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6763,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6791,6 +6897,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-broker"
+version = "0.19.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
 dependencies = [
@@ -6804,6 +6928,41 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-phase"
+version = "39.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-election-provider-support-benchmarking",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "strum 0.26.3",
+]
+
+[[package]]
+name = "pallet-election-provider-support-benchmarking"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-npos-elections",
  "sp-runtime",
 ]
 
@@ -7003,9 +7162,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-fast-unstake"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
 name = "pallet-grandpa"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7040,9 +7217,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-identity"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "enumflags2",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-message-queue"
+version = "43.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "environmental",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "pallet-mmr"
+version = "40.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-mmr-primitives",
+]
+
+[[package]]
 name = "pallet-session"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7061,9 +7285,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking"
+version = "40.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
+name = "pallet-staking-reward-fn"
+version = "22.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "log",
+ "sp-arithmetic",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7078,7 +7333,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7097,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7113,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7129,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7139,9 +7394,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-treasury"
+version = "39.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7150,6 +7424,20 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-vesting"
+version = "40.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
 ]
 
@@ -7447,9 +7735,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "polkadot-ckb-merkle-mountain-range"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221c71b432b38e494a0fdedb5f720e4cb974edf03a0af09e5b2238dbac7e6947"
+dependencies = [
+ "cfg-if",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7460,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bs58",
  "futures",
@@ -7477,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -7502,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -7526,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -7554,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -7574,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -7590,7 +7888,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -7616,6 +7914,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-runtime-common"
+version = "19.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "libsecp256k1",
+ "log",
+ "pallet-asset-rate",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-election-provider-multi-phase",
+ "pallet-fast-unstake",
+ "pallet-identity",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "slot-range-helper",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "static_assertions",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "bs58",
+ "frame-benchmarking",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-tracing",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "19.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "bitflags 1.3.2",
+ "bitvec",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-message-queue",
+ "pallet-mmr",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-metrics",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "static_assertions",
+]
+
+[[package]]
 name = "polkadot-sdk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7625,9 +8032,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-sdk-frame"
+version = "0.9.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-storage",
+ "sp-transaction-pool",
+ "sp-version",
+]
+
+[[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8865,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "log",
  "sp-core",
@@ -8876,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -8904,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "futures",
  "log",
@@ -8925,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8940,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "docify",
@@ -8966,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -8977,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9019,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "fnv",
  "futures",
@@ -9045,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9071,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -9094,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -9123,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9159,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9172,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -9216,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -9251,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -9274,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9297,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -9310,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "log",
  "polkavm",
@@ -9321,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "anyhow",
  "log",
@@ -9337,7 +9779,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "console",
  "futures",
@@ -9353,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -9367,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -9395,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.49.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -9445,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9455,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "ahash",
  "futures",
@@ -9474,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -9495,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -9530,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9549,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bs58",
  "bytes",
@@ -9568,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bytes",
  "fnv",
@@ -9602,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9611,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9643,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9663,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -9687,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.49.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9719,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -9734,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "directories",
@@ -9798,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9809,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -9829,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "chrono",
  "futures",
@@ -9848,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "chrono",
  "console",
@@ -9876,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -9887,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -9919,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -9936,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -10505,6 +10947,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
+name = "slot-range-helper"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "enumn",
+ "parity-scale-codec",
+ "paste",
+ "sp-runtime",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10669,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "hash-db",
@@ -10691,7 +11144,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -10705,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10717,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -10731,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10743,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10753,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10772,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "futures",
@@ -10786,7 +11239,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10802,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10820,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10837,7 +11290,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10848,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -10909,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10922,7 +11375,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2503)",
@@ -10932,7 +11385,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -10941,7 +11394,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10951,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10961,7 +11414,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10973,7 +11426,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10986,7 +11439,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bytes",
  "docify",
@@ -11012,7 +11465,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -11022,7 +11475,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11033,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -11042,7 +11495,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -11052,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11061,9 +11514,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-mmr-primitives"
+version = "36.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-ckb-merkle-mountain-range",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-debug-derive",
+ "sp-runtime",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sp-npos-elections"
+version = "36.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11073,7 +11556,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "backtrace",
  "regex",
@@ -11082,7 +11565,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -11092,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -11121,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11140,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "Inflector",
  "expander",
@@ -11153,7 +11636,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11167,7 +11650,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11180,7 +11663,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "hash-db",
  "log",
@@ -11200,7 +11683,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -11224,12 +11707,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11241,7 +11724,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11253,7 +11736,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -11264,7 +11747,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11273,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11287,7 +11770,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "ahash",
  "hash-db",
@@ -11309,7 +11792,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11326,7 +11809,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -11338,7 +11821,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11350,7 +11833,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -11539,7 +12022,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "16.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -11555,6 +12038,50 @@ dependencies = [
  "sp-runtime",
  "sp-weights",
  "xcm-procedural",
+]
+
+[[package]]
+name = "staging-xcm-builder"
+version = "20.1.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "environmental",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-asset-conversion",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "tracing",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "19.1.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
+dependencies = [
+ "environmental",
+ "frame-benchmarking",
+ "frame-support",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
+ "tracing",
 ]
 
 [[package]]
@@ -11651,7 +12178,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -11676,12 +12203,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -11701,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "http-body-util",
  "hyper 1.5.2",
@@ -11715,7 +12242,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -11740,7 +12267,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -11784,7 +12311,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -11802,7 +12329,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -12496,7 +13023,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -12507,7 +13034,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
@@ -13772,7 +14299,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#10af808e7ed66f83c65573b0bdd5f88207c38b62"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2503#f4dba53bfac614b054735aa725d2b0c44efda414"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,9 @@ substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk
 substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503" }
 
+# Polkadot
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
+
 # Cumulus primitives
 cumulus-pallet-weight-reclaim = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }
 cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2503", default-features = false }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -58,6 +58,9 @@ pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
 
+# Polkadot
+polkadot-runtime-common = { workspace = true }
+
 # Cumulus primitives
 cumulus-pallet-weight-reclaim = { workspace = true }
 
@@ -113,6 +116,8 @@ std = [
 	"pallet-evm-precompile-modexp/std",
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompile-simple/std",
+	# Polkadot
+	"polkadot-runtime-common/std",
 	# Cumulus primitives
 	"cumulus-pallet-weight-reclaim/std",
 ]
@@ -126,4 +131,5 @@ runtime-benchmarks = [
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-ethereum/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
 ]


### PR DESCRIPTION
The template runtime configuration sets FeeMultiplierUpdate to `ConstFeeMultiplier`, which does not take into consideration the current usage of the network. 

While this is a template, it is still good to provide a safe example for anyone integrating frontier in their runtimes.

When using `ConstFeeMultiplier`, fees do not reflect congestion, an attacker could cause a DoS against all zero-tip transactions for an extended period of time by just paying the regular transaction fees (and not exponentially raising fees, which would at least limit the duration of that attack).