### PR TITLE
Fix StorageWeightReclaim usage after updating to polkadot 2503

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,6 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "clap",
- "cumulus-pallet-weight-reclaim",
  "cumulus-primitives-proof-size-hostfunction",
  "fc-api",
  "fc-cli",

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -81,7 +81,6 @@ fp-rpc = { workspace = true, features = ["default"] }
 frontier-template-runtime = { workspace = true, features = ["std"] }
 
 # Cumulus primitives
-cumulus-pallet-weight-reclaim = { workspace = true }
 cumulus-primitives-proof-size-hostfunction = { workspace = true }
 
 [build-dependencies]

--- a/template/node/src/benchmarking.rs
+++ b/template/node/src/benchmarking.rs
@@ -121,7 +121,19 @@ pub fn create_benchmark_extrinsic(
 		.checked_next_power_of_two()
 		.map(|c| c / 2)
 		.unwrap_or(2) as u64;
-	let extra: runtime::SignedExtra = (
+	let extra: runtime::SignedExtra = cumulus_pallet_weight_reclaim::StorageWeightReclaim::<
+		runtime::Runtime,
+		(
+			frame_system::CheckNonZeroSender<runtime::Runtime>,
+			frame_system::CheckSpecVersion<runtime::Runtime>,
+			frame_system::CheckTxVersion<runtime::Runtime>,
+			frame_system::CheckGenesis<runtime::Runtime>,
+			frame_system::CheckMortality<runtime::Runtime>,
+			frame_system::CheckNonce<runtime::Runtime>,
+			frame_system::CheckWeight<runtime::Runtime>,
+			pallet_transaction_payment::ChargeTransactionPayment<runtime::Runtime>,
+		),
+	>::new((
 		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
 		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
 		frame_system::CheckTxVersion::<runtime::Runtime>::new(),
@@ -133,8 +145,7 @@ pub fn create_benchmark_extrinsic(
 		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
-		cumulus_pallet_weight_reclaim::StorageWeightReclaim::<runtime::Runtime, ()>::new(()),
-	);
+	));
 
 	let raw_payload = runtime::SignedPayload::from_raw(
 		call.clone(),
@@ -145,7 +156,6 @@ pub fn create_benchmark_extrinsic(
 			runtime::VERSION.transaction_version,
 			genesis_hash,
 			best_hash,
-			(),
 			(),
 			(),
 			(),

--- a/template/node/src/benchmarking.rs
+++ b/template/node/src/benchmarking.rs
@@ -121,19 +121,7 @@ pub fn create_benchmark_extrinsic(
 		.checked_next_power_of_two()
 		.map(|c| c / 2)
 		.unwrap_or(2) as u64;
-	let extra: runtime::SignedExtra = cumulus_pallet_weight_reclaim::StorageWeightReclaim::<
-		runtime::Runtime,
-		(
-			frame_system::CheckNonZeroSender<runtime::Runtime>,
-			frame_system::CheckSpecVersion<runtime::Runtime>,
-			frame_system::CheckTxVersion<runtime::Runtime>,
-			frame_system::CheckGenesis<runtime::Runtime>,
-			frame_system::CheckMortality<runtime::Runtime>,
-			frame_system::CheckNonce<runtime::Runtime>,
-			frame_system::CheckWeight<runtime::Runtime>,
-			pallet_transaction_payment::ChargeTransactionPayment<runtime::Runtime>,
-		),
-	>::new((
+	let extra = runtime::SignedExtra::new((
 		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
 		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
 		frame_system::CheckTxVersion::<runtime::Runtime>::new(),

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -109,17 +109,19 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 
 /// The SignedExtension to the basic transaction logic.
-pub type SignedExtra = (
-	frame_system::CheckNonZeroSender<Runtime>,
-	frame_system::CheckSpecVersion<Runtime>,
-	frame_system::CheckTxVersion<Runtime>,
-	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
-	frame_system::CheckNonce<Runtime>,
-	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	cumulus_pallet_weight_reclaim::StorageWeightReclaim<Runtime, ()>,
-);
+pub type SignedExtra = cumulus_pallet_weight_reclaim::StorageWeightReclaim<
+	Runtime,
+	(
+		frame_system::CheckNonZeroSender<Runtime>,
+		frame_system::CheckSpecVersion<Runtime>,
+		frame_system::CheckTxVersion<Runtime>,
+		frame_system::CheckGenesis<Runtime>,
+		frame_system::CheckEra<Runtime>,
+		frame_system::CheckNonce<Runtime>,
+		frame_system::CheckWeight<Runtime>,
+		pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	),
+>;
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =


### PR DESCRIPTION
# Description

Fix `StorageWeightReclaim` usage as wrapper as it is described [here](https://github.com/paritytech/polkadot-sdk/blob/25552a05d1326f82a38c59f07a1a6c0a527ce567/prdoc/stable2503/pr_6140.prdoc)