### PR TITLE
Fix(fc-rpc-v2-api): Make mix_hash optional and handle camelCase fields in Transaction

### DIFF
--- a/client/rpc-v2/types/src/block.rs
+++ b/client/rpc-v2/types/src/block.rs
@@ -85,7 +85,8 @@ pub struct Header {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub total_difficulty: Option<U256>,
 	/// Mix hash.
-	pub mix_hash: H256,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub mix_hash: Option<H256>,
 
 	/// Base fee per unit of gas, which is added by [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
 	#[serde(default, skip_serializing_if = "Option::is_none")]

--- a/client/rpc-v2/types/src/transaction/mod.rs
+++ b/client/rpc-v2/types/src/transaction/mod.rs
@@ -86,6 +86,7 @@ impl<'de> serde::Deserialize<'de> for TxType {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// [EIP-2718](https://eips.ethereum.org/EIPS/eip-27    gg  ) transaction type
 	#[serde(rename = "type")]


### PR DESCRIPTION
This PR the serialization and deserialization of a few types under the `fc-rpc-v2-api` crate.

- `mix_hash` is not applicable to frontier;
- Transaction struct under `fc-rpc-v2-api` did not expect field names to use camelCase.
