### PR TITLE
frame/eth: Fix cumulative gas incremental for block storage

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -464,7 +464,7 @@ impl<T: Config> Pallet<T> {
 					}
 					Receipt::EIP7702(d) => (d.logs.clone(), d.used_gas),
 				};
-				cumulative_gas_used = used_gas;
+				cumulative_gas_used += used_gas;
 				Self::logs_bloom(logs, &mut logs_bloom);
 			}
 		}


### PR DESCRIPTION
When the Ethereum block is stored within the frontier, the cumulative gas used should include the total amount of gas used by all transactions.

Before this PR, the `cumulative_gas_used` variable stored in the block was overwritten at each iteration through the included transactions. In other words, the block's `gas_used` represented the gas used of the last transaction (not the sum of all components).

For example, this is the equivalent code for substrate compute frame/revive: https://github.com/paritytech/polkadot-sdk/blob/96cb1e24c9247e43b446315c4935d83a241d83fc/substrate/frame/revive/rpc/src/client.rs#L644.

Now the counter is incremented to include the gas used by all transactions. This aligns the implementation and ensures we propagate the proper value within the block.

cc @athei @skunert @lrubasze 