### PR TITLE
Allow integration tests to attach to a running node

### DIFF
--- a/ts-tests/README.md
+++ b/ts-tests/README.md
@@ -34,3 +34,51 @@ FRONTIER_LOG="warn,rpc=trace" npm run test
 ```
 
 (The frontier node be listening for RPC on port 19933, mostly to avoid conflict with already running substrate node)
+
+## Attaching to Existing Frontier Node for Tests
+
+The test suite now supports attaching to an already running Frontier node instead of spawning a new one. This is useful for debugging with a node that has a debugger attached.
+
+### Usage
+
+Set the `FRONTIER_ATTACH` environment variable before running tests:
+
+```bash
+# Attach to existing node
+FRONTIER_ATTACH=true npm test
+
+# Or for a specific test
+FRONTIER_ATTACH=true npx mocha -r ts-node/register tests/test-eip7702.ts
+```
+
+### Requirements
+
+The existing node must be running with these parameters:
+- `--rpc-port=19932` (matches test suite expectations)
+- `--sealing=manual` (for controlled block production)
+- Other standard test parameters as shown in debug.json
+
+### Example Workflow
+
+1. Start your debug node:
+   ```bash
+   ./target/debug/frontier-template-node \
+     --chain=dev \
+     --validator \
+     --execution=Native \
+     --sealing=manual \
+     --no-grandpa \
+     --force-authoring \
+     --rpc-port=19932 \
+     --rpc-cors=all \
+     --rpc-methods=unsafe \
+     --rpc-external \
+     --tmp \
+     --unsafe-force-node-key-generation
+   ```
+
+2. Run tests with attachment mode:
+   ```bash
+   cd ts-tests
+   FRONTIER_ATTACH=true npm test
+   ```

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -60,7 +60,6 @@ export async function createAndFinalizeBlockNowait(web3: Web3) {
 
 export async function attachToFrontierNode(provider?: string): Promise<{
 	web3: Web3;
-	binary: null;
 	ethersjs: ethers.JsonRpcProvider;
 }> {
 	var web3;

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -88,10 +88,6 @@ export async function startFrontierNode(
 		}
 	}
 
-	if (!provider || provider == "http") {
-		web3 = new Web3(`http://127.0.0.1:${RPC_PORT}`);
-	}
-
 	const cmd = BINARY_PATH;
 	const args = [
 		`--chain=dev`,

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -85,7 +85,7 @@ export async function attachToFrontierNode(provider?: string): Promise<{
 		name: "frontier-dev",
 	});
 
-	return { web3, binary: null, ethersjs };
+	return { web3, ethersjs };
 }
 
 export async function startFrontierNode(

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -58,35 +58,6 @@ export async function createAndFinalizeBlockNowait(web3: Web3) {
 	}
 }
 
-export async function attachToFrontierNode(provider?: string): Promise<{
-	web3: Web3;
-	ethersjs: ethers.JsonRpcProvider;
-}> {
-	var web3;
-	if (!provider || provider == "http") {
-		web3 = new Web3(`http://127.0.0.1:${RPC_PORT}`);
-	} else if (provider == "ws") {
-		web3 = new Web3(`ws://127.0.0.1:${RPC_PORT}`);
-	}
-
-	// Check if node is running by trying to get chain ID
-	try {
-		const chainId = await web3.eth.getChainId();
-		console.log(`\x1b[32mAttached to existing Frontier node (Chain ID: ${chainId})\x1b[0m`);
-	} catch (error) {
-		console.error(`\x1b[31mFailed to connect to Frontier node at port ${RPC_PORT}\x1b[0m`);
-		console.error(`Make sure a node is running with --rpc-port=${RPC_PORT}`);
-		throw error;
-	}
-
-	let ethersjs = new ethers.JsonRpcProvider(`http://127.0.0.1:${RPC_PORT}`, {
-		chainId: CHAIN_ID,
-		name: "frontier-dev",
-	});
-
-	return { web3, ethersjs };
-}
-
 export async function startFrontierNode(
 	provider?: string,
 	additionalArgs: string[] = []
@@ -95,19 +66,28 @@ export async function startFrontierNode(
 	binary: ChildProcess;
 	ethersjs: ethers.JsonRpcProvider;
 }> {
-	// First check if a node is already running
+	let web3;
+	if (!provider || provider == "http") {
+		web3 = new Web3(`http://127.0.0.1:${RPC_PORT}`);
+	} else if (provider == "ws") {
+		web3 = new Web3(`ws://127.0.0.1:${RPC_PORT}`);
+	}
+
+	const ethersjs = new ethers.JsonRpcProvider(`http://127.0.0.1:${RPC_PORT}`, {
+		chainId: CHAIN_ID,
+		name: "frontier-dev",
+	});
+
 	const attachOnExisting = process.env.FRONTIER_ATTACH || false;
 	if (attachOnExisting) {
 		try {
-			const result = await attachToFrontierNode(provider);
 			// Return with a fake binary object to maintain API compatibility
-			return { ...result, binary: null as any };
-		} catch (error) {
+			return { web3, ethersjs, binary: null as any };
+		} catch (_error) {
 			console.log(`\x1b[33mNo existing node found, starting new one...\x1b[0m`);
 		}
 	}
 
-	var web3;
 	if (!provider || provider == "http") {
 		web3 = new Web3(`http://127.0.0.1:${RPC_PORT}`);
 	}
@@ -180,11 +160,6 @@ export async function startFrontierNode(
 	if (provider == "ws") {
 		web3 = new Web3(`ws://127.0.0.1:${RPC_PORT}`);
 	}
-
-	let ethersjs = new ethers.JsonRpcProvider(`http://127.0.0.1:${RPC_PORT}`, {
-		chainId: CHAIN_ID,
-		name: "frontier-dev",
-	});
 
 	return { web3, binary, ethersjs };
 }


### PR DESCRIPTION
## Description

The test suite now supports attaching to an already running Frontier node instead of spawning a new one. This is useful for debugging with a node that has a debugger attached.

### Usage

Set the `FRONTIER_ATTACH` environment variable before running tests:

```bash
# Attach to existing node
FRONTIER_ATTACH=true npm test

# Or for a specific test
FRONTIER_ATTACH=true npx mocha -r ts-node/register tests/test-eip7702.ts
```

### Requirements

The existing node must be running with these parameters:
- `--rpc-port=19932` (matches test suite expectations)
- `--sealing=manual` (for controlled block production)
- Other standard test parameters as shown in debug.json

### Example Workflow

1. Start your debug node:
   ```bash
   ./target/debug/frontier-template-node \
     --chain=dev \
     --validator \
     --execution=Native \
     --sealing=manual \
     --no-grandpa \
     --force-authoring \
     --rpc-port=19932 \
     --rpc-cors=all \
     --rpc-methods=unsafe \
     --rpc-external \
     --tmp \
     --unsafe-force-node-key-generation
   ```

2. Run tests with attachment mode:
   ```bash
   cd ts-tests
   FRONTIER_ATTACH=true npm test
   ```
